### PR TITLE
docs(scaffolder-backend-module-gcp): use secrets context for sensitive values in templates

### DIFF
--- a/workspaces/scaffolder-backend-module-gcp/examples/secrets-manager-create.template.yaml
+++ b/workspaces/scaffolder-backend-module-gcp/examples/secrets-manager-create.template.yaml
@@ -48,7 +48,7 @@ spec:
       action: datolabs:gcp:secrets-manager:create
       input:
         name: ${{ parameters.name }}
-        value: ${{ parameters.value }}
+        value: ${{ secrets.value }}
         project: ${{ parameters.project }}
         labels:
           system: ${{ parameters.system | parseEntityRef | pick('name') }}

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/README.md
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/README.md
@@ -69,8 +69,10 @@ steps:
     action: datolabs:gcp:secrets-manager:create
     input:
       name: ${{ parameters.name }}
-      value: ${{ parameters.value }}
+      value: ${{ secrets.value }}
       project: ${{ parameters.project }}
 ```
+
+Please make sure to add `ui:field: Secret` to the secret value parameter in the template to ensure it is treated as sensitive.
 
 Full template examples can be found in the [examples](../../examples) directory.


### PR DESCRIPTION
Fixes https://github.com/backstage/backstage/pull/28264#issuecomment-2559247651.