### PR TITLE
fix(gcp): update module to support backstage 1.35

### DIFF
--- a/workspaces/scaffolder-backend-module-gcp/.changeset/famous-ducks-know.md
+++ b/workspaces/scaffolder-backend-module-gcp/.changeset/famous-ducks-know.md
@@ -1,0 +1,5 @@
+---
+'@datolabs/plugin-scaffolder-backend-module-gcp': patch
+---
+
+Updated to support for Backstage 1.35


### PR DESCRIPTION
Updated the GCP scaffolder backend module to ensure compatibility with Backstage version 1.35