### PR TITLE
feat: Add Google Access Token support for GCP actions

### DIFF
--- a/workspaces/scaffolder-backend-module-gcp/.changeset/hot-carpets-shout.md
+++ b/workspaces/scaffolder-backend-module-gcp/.changeset/hot-carpets-shout.md
@@ -1,0 +1,5 @@
+---
+'@datolabs/plugin-scaffolder-backend-module-gcp': minor
+---
+
+Add ability to use a passed user Oauth Token to the actions

--- a/workspaces/scaffolder-backend-module-gcp/examples/field-extension/GoogleAccessTokenFieldExtension.tsx
+++ b/workspaces/scaffolder-backend-module-gcp/examples/field-extension/GoogleAccessTokenFieldExtension.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Datolabs, MB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ * Example custom Scaffolder field extension that fetches the signed-in
+ * user's Google OAuth access token and forwards it to the Scaffolder
+ * task as `secrets.googleAccessToken`. The GCP scaffolder actions in
+ * `@datolabs/plugin-scaffolder-backend-module-gcp` will then authenticate
+ * to GCP as the end user instead of using a service account.
+ *
+ * This file is intentionally provided as a copy/paste example rather
+ * than a published package. Drop it into your Backstage app (typically
+ * `packages/app/src/scaffolder/GoogleAccessTokenFieldExtension/`) and register it as shown below.
+ * --------------------------------------------------------------------------
+ */
+import React, { useEffect } from 'react';
+import { useApi, googleAuthApiRef } from '@backstage/core-plugin-api';
+import { useTemplateSecrets } from '@backstage/plugin-scaffolder-react';
+import type { FieldExtensionComponentProps } from '@backstage/plugin-scaffolder-react';
+
+/**
+ * Scopes requested for the user's Google access token. Adjust to the
+ * least-privilege set required by the GCP actions you invoke. The
+ * `cloud-platform` scope grants access to all Google Cloud APIs.
+ */
+const DEFAULT_SCOPES = ['https://www.googleapis.com/auth/cloud-platform'];
+
+export type GoogleAccessTokenFieldUiOptions = {
+    /** Override the requested OAuth scopes. */
+    scopes?: string[];
+    /** Override the secret key the token is stored under. Defaults to `googleAccessToken`. */
+    secretKey?: string;
+};
+
+/**
+ * Field component. Renders nothing — silently acquires the signed-in
+ * user's Google OAuth access token and stores it in Scaffolder task
+ * secrets so backend GCP actions can use it.
+ *
+ * Requires `additionalScopes` to include the requested scopes in the
+ * Google auth provider config so the session refresh token covers them.
+ */
+export const GoogleAccessTokenField = (
+    props: FieldExtensionComponentProps<
+        string,
+        GoogleAccessTokenFieldUiOptions
+    >,
+) => {
+    const { onChange, uiSchema } = props;
+    const googleAuth = useApi(googleAuthApiRef);
+    const { setSecrets } = useTemplateSecrets();
+
+    const scopes = uiSchema?.['ui:options']?.scopes ?? DEFAULT_SCOPES;
+    const secretKey =
+        uiSchema?.['ui:options']?.secretKey ?? 'googleAccessToken';
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const token = await googleAuth.getAccessToken(scopes);
+                if (cancelled) return;
+                setSecrets({ [secretKey]: token });
+                onChange(token);
+            } catch (e) {
+                if (!cancelled) {
+                    // eslint-disable-next-line no-console
+                    console.error(
+                        '[GoogleAccessTokenField] failed to acquire token:',
+                        e,
+                    );
+                }
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return null;
+};

--- a/workspaces/scaffolder-backend-module-gcp/examples/field-extension/GoogleAccessTokenFieldExtension.tsx
+++ b/workspaces/scaffolder-backend-module-gcp/examples/field-extension/GoogleAccessTokenFieldExtension.tsx
@@ -38,10 +38,10 @@ import type { FieldExtensionComponentProps } from '@backstage/plugin-scaffolder-
 const DEFAULT_SCOPES = ['https://www.googleapis.com/auth/cloud-platform'];
 
 export type GoogleAccessTokenFieldUiOptions = {
-    /** Override the requested OAuth scopes. */
-    scopes?: string[];
-    /** Override the secret key the token is stored under. Defaults to `googleAccessToken`. */
-    secretKey?: string;
+  /** Override the requested OAuth scopes. */
+  scopes?: string[];
+  /** Override the secret key the token is stored under. Defaults to `googleAccessToken`. */
+  secretKey?: string;
 };
 
 /**
@@ -53,42 +53,35 @@ export type GoogleAccessTokenFieldUiOptions = {
  * Google auth provider config so the session refresh token covers them.
  */
 export const GoogleAccessTokenField = (
-    props: FieldExtensionComponentProps<
-        string,
-        GoogleAccessTokenFieldUiOptions
-    >,
+  props: FieldExtensionComponentProps<string, GoogleAccessTokenFieldUiOptions>,
 ) => {
-    const { onChange, uiSchema } = props;
-    const googleAuth = useApi(googleAuthApiRef);
-    const { setSecrets } = useTemplateSecrets();
+  const { onChange, uiSchema } = props;
+  const googleAuth = useApi(googleAuthApiRef);
+  const { setSecrets } = useTemplateSecrets();
 
-    const scopes = uiSchema?.['ui:options']?.scopes ?? DEFAULT_SCOPES;
-    const secretKey =
-        uiSchema?.['ui:options']?.secretKey ?? 'googleAccessToken';
+  const scopes = uiSchema?.['ui:options']?.scopes ?? DEFAULT_SCOPES;
+  const secretKey = uiSchema?.['ui:options']?.secretKey ?? 'googleAccessToken';
 
-    useEffect(() => {
-        let cancelled = false;
-        (async () => {
-            try {
-                const token = await googleAuth.getAccessToken(scopes);
-                if (cancelled) return;
-                setSecrets({ [secretKey]: token });
-                onChange(token);
-            } catch (e) {
-                if (!cancelled) {
-                    // eslint-disable-next-line no-console
-                    console.error(
-                        '[GoogleAccessTokenField] failed to acquire token:',
-                        e,
-                    );
-                }
-            }
-        })();
-        return () => {
-            cancelled = true;
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await googleAuth.getAccessToken(scopes);
+        if (cancelled) return;
+        setSecrets({ [secretKey]: token });
+        onChange(token);
+      } catch (e) {
+        if (!cancelled) {
+          // eslint-disable-next-line no-console
+          console.error('[GoogleAccessTokenField] failed to acquire token:', e);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-    return null;
+  return null;
 };

--- a/workspaces/scaffolder-backend-module-gcp/examples/field-extension/GoogleAccessTokenFieldExtension.tsx
+++ b/workspaces/scaffolder-backend-module-gcp/examples/field-extension/GoogleAccessTokenFieldExtension.tsx
@@ -40,14 +40,18 @@ const DEFAULT_SCOPES = ['https://www.googleapis.com/auth/cloud-platform'];
 export type GoogleAccessTokenFieldUiOptions = {
   /** Override the requested OAuth scopes. */
   scopes?: string[];
-  /** Override the secret key the token is stored under. Defaults to `googleAccessToken`. */
-  secretKey?: string;
 };
 
 /**
  * Field component. Renders nothing — silently acquires the signed-in
  * user's Google OAuth access token and stores it in Scaffolder task
- * secrets so backend GCP actions can use it.
+ * secrets (under `googleAccessToken`) so backend GCP actions can use it.
+ *
+ * The token is intentionally only written to `setSecrets` — scaffolder
+ * secrets stay in memory for the task run and are not persisted. The
+ * field deliberately does NOT call `onChange` with the token value, so
+ * the token never ends up in the form's `parameters` (which scaffolder
+ * persists to its database).
  *
  * Requires `additionalScopes` to include the requested scopes in the
  * Google auth provider config so the session refresh token covers them.
@@ -55,12 +59,11 @@ export type GoogleAccessTokenFieldUiOptions = {
 export const GoogleAccessTokenField = (
   props: FieldExtensionComponentProps<string, GoogleAccessTokenFieldUiOptions>,
 ) => {
-  const { onChange, uiSchema } = props;
+  const { uiSchema } = props;
   const googleAuth = useApi(googleAuthApiRef);
   const { setSecrets } = useTemplateSecrets();
 
   const scopes = uiSchema?.['ui:options']?.scopes ?? DEFAULT_SCOPES;
-  const secretKey = uiSchema?.['ui:options']?.secretKey ?? 'googleAccessToken';
 
   useEffect(() => {
     let cancelled = false;
@@ -68,8 +71,7 @@ export const GoogleAccessTokenField = (
       try {
         const token = await googleAuth.getAccessToken(scopes);
         if (cancelled) return;
-        setSecrets({ [secretKey]: token });
-        onChange(token);
+        setSecrets({ googleAccessToken: token });
       } catch (e) {
         if (!cancelled) {
           // eslint-disable-next-line no-console

--- a/workspaces/scaffolder-backend-module-gcp/examples/field-extension/README.md
+++ b/workspaces/scaffolder-backend-module-gcp/examples/field-extension/README.md
@@ -22,39 +22,48 @@ service account.
    is configured and your users sign in with Google.
 2. The frontend `googleAuthApiRef` is wired up (it ships in
    `@backstage/core-plugin-api`).
-3. `@backstage/plugin-scaffolder-react` is installed in your app
-   (it is, by default).
+3. `@backstage/plugin-scaffolder-react` and `@backstage/plugin-scaffolder`
+   are installed in your app (they are, by default).
 
 ## Installation
 
+The example is split into two files so the React component and the
+Scaffolder plugin registration live separately, matching common
+Backstage app conventions.
+
 1. Copy [`GoogleAccessTokenFieldExtension.tsx`](./GoogleAccessTokenFieldExtension.tsx)
-   into your Backstage app, e.g.
+   into your Backstage app at
    `packages/app/src/scaffolder/GoogleAccessTokenFieldExtension/GoogleAccessTokenFieldExtension.tsx`.
-2. Export the extension from an `index.ts` file in the same directory:
+   This file exports the React component `GoogleAccessTokenField`.
+
+2. Create `packages/app/src/scaffolder/GoogleAccessTokenFieldExtension/extensions.ts`
+   to register the component as a Scaffolder field extension:
 
    ```tsx
-   export { GoogleAccessTokenFieldExtension } from './GoogleAccessTokenFieldExtension';
+   import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+   import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
+   import { GoogleAccessTokenField } from './GoogleAccessTokenFieldExtension';
+
+   /**
+    * Registers the field with the Scaffolder plugin so templates can
+    * reference it via `ui:field: GoogleAccessToken`.
+    */
+   export const GoogleAccessTokenFieldExtension = scaffolderPlugin.provide(
+     createScaffolderFieldExtension({
+       name: 'GoogleAccessToken',
+       component: GoogleAccessTokenField,
+     }),
+   );
    ```
-2. Register the extension with Scaffolder in `/packages/app/src/scaffolder/GoogleAccessTokenFieldExtension/extensions.ts`:
 
-   ```tsx
-  import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
-  import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
-  import { GoogleAccessTokenField } from './GoogleAccessTokenFieldExtension';
+3. Create `packages/app/src/scaffolder/GoogleAccessTokenFieldExtension/index.ts`
+   to re-export the registration for convenient importing:
 
-  /**
-  * Register the field extension with the Scaffolder plugin.
-  * Referenced from a template via `ui:field: GoogleAccessToken`.
-  */
-  export const GoogleAccessTokenFieldExtension = scaffolderPlugin.provide(
-      createScaffolderFieldExtension({
-          name: 'GoogleAccessToken',
-          component: GoogleAccessTokenField,
-      }),
-  );
-
+   ```ts
+   export { GoogleAccessTokenFieldExtension } from './extensions';
    ```
-2. Register the extension with the Scaffolder route in
+
+4. Register the extension inside the Scaffolder route in
    `packages/app/src/App.tsx`:
 
    ```tsx
@@ -63,18 +72,20 @@ service account.
 
    // ...
 
-    <ScaffolderFieldExtensions>
-        <SelectFieldFromApiExtension />
-        <GithubTeamPickerExtension />
-        <GoogleAccessTokenFieldExtension />
-    </ScaffolderFieldExtensions>
+   <Route path="/create" element={<ScaffolderPage />}>
+     <ScaffolderFieldExtensions>
+       {/* other field extensions you already have */}
+       <GoogleAccessTokenFieldExtension />
+     </ScaffolderFieldExtensions>
+   </Route>;
    ```
 
 ## Using the field in a template
 
-Add a hidden parameter that uses the field. The field component renders
-nothing visible; it just populates `secrets.googleAccessToken` when the
-form loads.
+Add a hidden parameter that uses the field. The field renders nothing
+visible — it just populates `secrets.googleAccessToken` (and the form
+parameter value) when the form loads, so the backend GCP action can
+pick it up automatically.
 
 ```yaml
 apiVersion: scaffolder.backstage.io/v1beta3
@@ -82,7 +93,7 @@ kind: Template
 metadata:
   name: create-gcp-gcs-bucket
   title: Create a GCP GCS Bucket
-  description: Creates a new GCS Bucket.
+  description: Creates a new GCS Bucket as the signed-in user.
   tags:
     - gcp
     - example
@@ -94,6 +105,9 @@ spec:
         - project
         - bucketName
       properties:
+        # Hidden field — invokes the field extension to acquire the
+        # user's Google OAuth access token and stash it in
+        # `secrets.googleAccessToken` for the backend action.
         googleToken:
           type: string
           ui:field: GoogleAccessToken
@@ -103,33 +117,25 @@ spec:
             scopes:
               - https://www.googleapis.com/auth/cloud-platform
             secretKey: googleAccessToken
-          # Hide the token from the user in the review step, since it's not relevant to them and looks scary. The field is already marked as a secret, so it won't be included in logs or API responses.
+          # Hide from the review step so users aren't confused by a
+          # mysterious blank/opaque value.
           ui:backstage:
             review:
               show: false
 
         bucketName:
-          title: Name of GCS Bucket to create. Must be globally unique.
+          title: Bucket name (must be globally unique)
           type: string
-          description: Bucket Name
         project:
           title: Project ID
           type: string
-          description: Project ID
         autoclass:
           title: Auto Class
           type: boolean
-          properties:
-            enabled:
-              type: boolean
-              title: Enable Auto Class
-              description: Enable Auto Class
-              default: true
           default: true
         location:
           title: Location
           type: string
-          description: Location
           default: us-central1
 
   steps:
@@ -141,7 +147,8 @@ spec:
         project: ${{ parameters.project }}
         autoClass: ${{ parameters.autoclass }}
         location: ${{ parameters.location }}
-        token: ${{ parameters.googleToken }}
+        # No `token` input is needed — the action automatically reads
+        # `secrets.googleAccessToken`.
 
   output:
     links:
@@ -149,12 +156,51 @@ spec:
         url: https://console.cloud.google.com/storage/browser?project=${{ parameters.project }}
 ```
 
+### Alternative: pass the token explicitly as an action input
+
+The field component also writes the token to its own form value via
+`onChange(token)`, so if you'd rather not rely on Scaffolder secrets you
+can pass it through as a plain input:
+
+```yaml
+steps:
+  - id: create-bucket
+    action: datolabs:gcp:bucket:create
+    input:
+      bucketName: ${{ parameters.bucketName }}
+      project: ${{ parameters.project }}
+      token: ${{ parameters.googleToken }}
+```
+
+The action prefers an explicit `token` input over `secrets.googleAccessToken`.
+You should pick one of the two approaches, not both.
+
+## How to verify it's working
+
+Each GCP action logs which credential source it ended up using.
+After running a template, look in the Scaffolder task log for one of:
+
+- `using Google OAuth access token from secrets.googleAccessToken (length=…)`
+  — the field extension is wired up and the user's token reached the
+  action.
+- `using Google OAuth access token from action input (length=…)` — you
+  passed the token via the explicit `token` input.
+- `no Google OAuth access token provided; falling back to Application Default Credentials`
+  — the action did not receive a token; it will use ADC on the backend.
+
+The token value itself is never logged.
+
 ## Notes & caveats
 
-- **Scopes.** Request the least-privilege scopes you need. The example
-  defaults to `https://www.googleapis.com/auth/cloud-platform`, which
-  grants access to all Google Cloud APIs the user already has IAM
-  rights to. You can narrow this with `ui:options.scopes`.
+- **Scopes.** Request the least-privilege scopes you need. The default
+  `https://www.googleapis.com/auth/cloud-platform` grants access to all
+  Google Cloud APIs the user already has IAM rights to. You can narrow
+  this with `ui:options.scopes`.
+- **Additional scopes in the auth provider config.** For
+  `googleAuth.getAccessToken(scopes)` to return a usable token, those
+  scopes must either have been granted during sign-in or be requestable
+  by the user. In most setups Backstage's Google auth provider will
+  prompt the user for consent on the first request.
 - **Token lifetime.** Google access tokens are short-lived (~1 hour).
   The token is captured when the form loads, so very long-running
   scaffolder tasks could outlive it. For most template runs this is
@@ -163,6 +209,10 @@ spec:
   (e.g. `roles/secretmanager.admin`, `roles/storage.admin`,
   `roles/resourcemanager.projectCreator`) on the target project /
   parent. Otherwise the action fails with a permission error.
+- **Error reporting.** The example component logs token-acquisition
+  failures to the browser console (`[GoogleAccessTokenField] failed to
+acquire token: …`) and renders nothing. If you want the user to see
+  the error inline, render an error element from the component instead.
 - **Fallback.** If you do not register this extension (or the user
   isn't signed in with Google), the GCP actions fall back to
   Application Default Credentials on the backend.

--- a/workspaces/scaffolder-backend-module-gcp/examples/field-extension/README.md
+++ b/workspaces/scaffolder-backend-module-gcp/examples/field-extension/README.md
@@ -1,0 +1,168 @@
+# Google Access Token field extension (example)
+
+This directory contains an example custom Backstage Scaffolder
+[field extension](https://backstage.io/docs/features/software-templates/writing-custom-field-extensions)
+that obtains the signed-in user's Google OAuth access token in the
+browser and forwards it to the Scaffolder task as a secret named
+`googleAccessToken`.
+
+The GCP scaffolder actions in
+`@datolabs/plugin-scaffolder-backend-module-gcp` look for that secret
+(see [the plugin README](../../plugins/scaffolder-backend-module-gcp/README.md#authentication))
+and use it to authenticate to GCP as the end user — so you don't need a
+service account.
+
+> The file is intentionally provided as copy/paste example code, not as
+> a published npm package, because field extensions live in your
+> Backstage app (`packages/app`).
+
+## Prerequisites
+
+1. The [Backstage Google auth provider](https://backstage.io/docs/auth/google/provider/)
+   is configured and your users sign in with Google.
+2. The frontend `googleAuthApiRef` is wired up (it ships in
+   `@backstage/core-plugin-api`).
+3. `@backstage/plugin-scaffolder-react` is installed in your app
+   (it is, by default).
+
+## Installation
+
+1. Copy [`GoogleAccessTokenFieldExtension.tsx`](./GoogleAccessTokenFieldExtension.tsx)
+   into your Backstage app, e.g.
+   `packages/app/src/scaffolder/GoogleAccessTokenFieldExtension/GoogleAccessTokenFieldExtension.tsx`.
+2. Export the extension from an `index.ts` file in the same directory:
+
+   ```tsx
+   export { GoogleAccessTokenFieldExtension } from './GoogleAccessTokenFieldExtension';
+   ```
+2. Register the extension with Scaffolder in `/packages/app/src/scaffolder/GoogleAccessTokenFieldExtension/extensions.ts`:
+
+   ```tsx
+  import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+  import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
+  import { GoogleAccessTokenField } from './GoogleAccessTokenFieldExtension';
+
+  /**
+  * Register the field extension with the Scaffolder plugin.
+  * Referenced from a template via `ui:field: GoogleAccessToken`.
+  */
+  export const GoogleAccessTokenFieldExtension = scaffolderPlugin.provide(
+      createScaffolderFieldExtension({
+          name: 'GoogleAccessToken',
+          component: GoogleAccessTokenField,
+      }),
+  );
+
+   ```
+2. Register the extension with the Scaffolder route in
+   `packages/app/src/App.tsx`:
+
+   ```tsx
+   import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder-react';
+   import { GoogleAccessTokenFieldExtension } from './scaffolder/GoogleAccessTokenFieldExtension';
+
+   // ...
+
+    <ScaffolderFieldExtensions>
+        <SelectFieldFromApiExtension />
+        <GithubTeamPickerExtension />
+        <GoogleAccessTokenFieldExtension />
+    </ScaffolderFieldExtensions>
+   ```
+
+## Using the field in a template
+
+Add a hidden parameter that uses the field. The field component renders
+nothing visible; it just populates `secrets.googleAccessToken` when the
+form loads.
+
+```yaml
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-gcp-gcs-bucket
+  title: Create a GCP GCS Bucket
+  description: Creates a new GCS Bucket.
+  tags:
+    - gcp
+    - example
+spec:
+  type: template
+  parameters:
+    - title: Bucket Details
+      required:
+        - project
+        - bucketName
+      properties:
+        googleToken:
+          type: string
+          ui:field: GoogleAccessToken
+          ui:widget: hidden
+          ui:options:
+            # Optional — defaults shown.
+            scopes:
+              - https://www.googleapis.com/auth/cloud-platform
+            secretKey: googleAccessToken
+          # Hide the token from the user in the review step, since it's not relevant to them and looks scary. The field is already marked as a secret, so it won't be included in logs or API responses.
+          ui:backstage:
+            review:
+              show: false
+
+        bucketName:
+          title: Name of GCS Bucket to create. Must be globally unique.
+          type: string
+          description: Bucket Name
+        project:
+          title: Project ID
+          type: string
+          description: Project ID
+        autoclass:
+          title: Auto Class
+          type: boolean
+          properties:
+            enabled:
+              type: boolean
+              title: Enable Auto Class
+              description: Enable Auto Class
+              default: true
+          default: true
+        location:
+          title: Location
+          type: string
+          description: Location
+          default: us-central1
+
+  steps:
+    - id: create-bucket
+      name: Create GCP Bucket
+      action: datolabs:gcp:bucket:create
+      input:
+        bucketName: ${{ parameters.bucketName }}
+        project: ${{ parameters.project }}
+        autoClass: ${{ parameters.autoclass }}
+        location: ${{ parameters.location }}
+        token: ${{ parameters.googleToken }}
+
+  output:
+    links:
+      - title: View the Bucket in GCP Console
+        url: https://console.cloud.google.com/storage/browser?project=${{ parameters.project }}
+```
+
+## Notes & caveats
+
+- **Scopes.** Request the least-privilege scopes you need. The example
+  defaults to `https://www.googleapis.com/auth/cloud-platform`, which
+  grants access to all Google Cloud APIs the user already has IAM
+  rights to. You can narrow this with `ui:options.scopes`.
+- **Token lifetime.** Google access tokens are short-lived (~1 hour).
+  The token is captured when the form loads, so very long-running
+  scaffolder tasks could outlive it. For most template runs this is
+  fine.
+- **Permissions.** The user must have the relevant GCP IAM roles
+  (e.g. `roles/secretmanager.admin`, `roles/storage.admin`,
+  `roles/resourcemanager.projectCreator`) on the target project /
+  parent. Otherwise the action fails with a permission error.
+- **Fallback.** If you do not register this extension (or the user
+  isn't signed in with Google), the GCP actions fall back to
+  Application Default Credentials on the backend.

--- a/workspaces/scaffolder-backend-module-gcp/examples/field-extension/README.md
+++ b/workspaces/scaffolder-backend-module-gcp/examples/field-extension/README.md
@@ -83,9 +83,11 @@ Backstage app conventions.
 ## Using the field in a template
 
 Add a hidden parameter that uses the field. The field renders nothing
-visible — it just populates `secrets.googleAccessToken` (and the form
-parameter value) when the form loads, so the backend GCP action can
-pick it up automatically.
+visible — it populates `secrets.googleAccessToken` when the form loads
+so the backend GCP action can pick it up automatically. The token is
+written only to scaffolder secrets (which stay in memory) and never to
+the form's `parameters`, so it is not persisted to the scaffolder
+database.
 
 ```yaml
 apiVersion: scaffolder.backstage.io/v1beta3
@@ -107,21 +109,16 @@ spec:
       properties:
         # Hidden field — invokes the field extension to acquire the
         # user's Google OAuth access token and stash it in
-        # `secrets.googleAccessToken` for the backend action.
+        # `secrets.googleAccessToken` for the backend action. The
+        # parameter value itself stays empty.
         googleToken:
           type: string
           ui:field: GoogleAccessToken
           ui:widget: hidden
           ui:options:
-            # Optional — defaults shown.
+            # Optional — default shown.
             scopes:
               - https://www.googleapis.com/auth/cloud-platform
-            secretKey: googleAccessToken
-          # Hide from the review step so users aren't confused by a
-          # mysterious blank/opaque value.
-          ui:backstage:
-            review:
-              show: false
 
         bucketName:
           title: Bucket name (must be globally unique)
@@ -147,33 +144,14 @@ spec:
         project: ${{ parameters.project }}
         autoClass: ${{ parameters.autoclass }}
         location: ${{ parameters.location }}
-        # No `token` input is needed — the action automatically reads
-        # `secrets.googleAccessToken`.
+        # No token input — the action reads `secrets.googleAccessToken`
+        # directly.
 
   output:
     links:
       - title: View the Bucket in GCP Console
         url: https://console.cloud.google.com/storage/browser?project=${{ parameters.project }}
 ```
-
-### Alternative: pass the token explicitly as an action input
-
-The field component also writes the token to its own form value via
-`onChange(token)`, so if you'd rather not rely on Scaffolder secrets you
-can pass it through as a plain input:
-
-```yaml
-steps:
-  - id: create-bucket
-    action: datolabs:gcp:bucket:create
-    input:
-      bucketName: ${{ parameters.bucketName }}
-      project: ${{ parameters.project }}
-      token: ${{ parameters.googleToken }}
-```
-
-The action prefers an explicit `token` input over `secrets.googleAccessToken`.
-You should pick one of the two approaches, not both.
 
 ## How to verify it's working
 
@@ -183,8 +161,6 @@ After running a template, look in the Scaffolder task log for one of:
 - `using Google OAuth access token from secrets.googleAccessToken (length=…)`
   — the field extension is wired up and the user's token reached the
   action.
-- `using Google OAuth access token from action input (length=…)` — you
-  passed the token via the explicit `token` input.
 - `no Google OAuth access token provided; falling back to Application Default Credentials`
   — the action did not receive a token; it will use ADC on the backend.
 

--- a/workspaces/scaffolder-backend-module-gcp/examples/field-extension/extensions.ts
+++ b/workspaces/scaffolder-backend-module-gcp/examples/field-extension/extensions.ts
@@ -7,8 +7,8 @@ import { GoogleAccessTokenField } from './GoogleAccessTokenFieldExtension';
  * Referenced from a template via `ui:field: GoogleAccessToken`.
  */
 export const GoogleAccessTokenFieldExtension = scaffolderPlugin.provide(
-    createScaffolderFieldExtension({
-        name: 'GoogleAccessToken',
-        component: GoogleAccessTokenField,
-    }),
+  createScaffolderFieldExtension({
+    name: 'GoogleAccessToken',
+    component: GoogleAccessTokenField,
+  }),
 );

--- a/workspaces/scaffolder-backend-module-gcp/examples/field-extension/extensions.ts
+++ b/workspaces/scaffolder-backend-module-gcp/examples/field-extension/extensions.ts
@@ -1,0 +1,14 @@
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
+import { GoogleAccessTokenField } from './GoogleAccessTokenFieldExtension';
+
+/**
+ * Register the field extension with the Scaffolder plugin.
+ * Referenced from a template via `ui:field: GoogleAccessToken`.
+ */
+export const GoogleAccessTokenFieldExtension = scaffolderPlugin.provide(
+    createScaffolderFieldExtension({
+        name: 'GoogleAccessToken',
+        component: GoogleAccessTokenField,
+    }),
+);

--- a/workspaces/scaffolder-backend-module-gcp/examples/field-extension/index.ts
+++ b/workspaces/scaffolder-backend-module-gcp/examples/field-extension/index.ts
@@ -1,0 +1,1 @@
+export { GoogleAccessTokenFieldExtension } from './extensions';

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/README.md
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/README.md
@@ -36,10 +36,10 @@ This plugin supports two authentication modes:
 
 #### Using the end-user's Google OAuth token
 
-Each action accepts the user's Google OAuth access token via either:
-
-- `ctx.secrets.googleAccessToken` (recommended), or
-- an explicit `token` input on the action.
+Each action reads the user's Google OAuth access token from
+`ctx.secrets.googleAccessToken`. Secrets stay in memory for the task
+run and are not persisted to the scaffolder database, so the token is
+never written to durable storage.
 
 A typical setup:
 
@@ -118,7 +118,6 @@ Each action logs which credential source it ended up using when it runs.
 Look for one of these lines in the Scaffolder task log:
 
 - `using Google OAuth access token from secrets.googleAccessToken (length=…)`
-- `using Google OAuth access token from action input (length=…)`
 - `no Google OAuth access token provided; falling back to Application Default Credentials`
 
 The token value itself is never logged.

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/README.md
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/README.md
@@ -23,15 +23,50 @@ backend.add(import('@datolabs/plugin-scaffolder-backend-module-gcp'));
 
 ### Authentication
 
-This plugin uses Application Default Credentials (ADC) for authentication with GCP services. ADC provides a strategy to automatically find credentials based on the application environment.
+This plugin supports two authentication modes:
 
-The authentication library searches for credentials in the following order:
+1. **End-user OAuth token (recommended)** — the action authenticates as the
+   Backstage user that triggered the template. GCP API calls are then
+   subject to that user's IAM permissions, removing the need for a
+   long-lived service account.
+2. **Application Default Credentials (ADC)** — used as a fallback when no
+   user token is provided.
+
+#### Using the end-user's Google OAuth token
+
+Each action accepts the user's Google OAuth access token via either:
+
+- `ctx.secrets.googleAccessToken` (recommended), or
+- an explicit `token` input on the action.
+
+A typical setup:
+
+1. Configure the [Google auth provider](https://backstage.io/docs/auth/google/provider/)
+   in your Backstage backend so users can sign in with Google. See the
+   [`broadinstitute/backstage` reference implementation](https://github.com/broadinstitute/backstage/blob/main/backstage/packages/backend/src/index.ts#L30-L93)
+   for a working example.
+2. In the frontend, request a Google access token with the scopes the
+   action needs (e.g. `https://www.googleapis.com/auth/cloud-platform`)
+   using `googleAuthApiRef.getAccessToken(...)` and forward it to the
+   scaffolder task as a secret named `googleAccessToken`. This is
+   typically done with a custom scaffolder field extension — a working
+   copy/paste example is available in
+   [`examples/field-extension`](../../examples/field-extension).
+3. The action will then authenticate to GCP as the signed-in user.
+
+Make sure the user has the necessary IAM roles for the action being
+invoked.
+
+#### Application Default Credentials (fallback)
+
+When no user token is supplied, the plugin falls back to ADC. Credentials
+are searched in this order:
 
 1. `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 2. User credentials set up by using the Google Cloud CLI.
 3. The attached service account (when running on GCP).
 
-#### Local Development
+##### Local Development
 
 For local development, you have two options:
 
@@ -47,11 +82,15 @@ For local development, you have two options:
    gcloud auth application-default login
    ```
 
-#### Production Environment
+##### Production Environment
 
-For production deployments on GCP (Cloud Run, GKE, etc.), we recommend using the default compute service account or attaching a custom service account to your workload. This is more secure than using service account keys.
+For production deployments on GCP (Cloud Run, GKE, etc.), we recommend
+using the default compute service account or attaching a custom service
+account to your workload. This is more secure than using service account
+keys.
 
-Make sure the service account has the necessary IAM roles for the actions you plan to use:
+Make sure the principal (user or service account) has the necessary IAM
+roles for the actions you plan to use:
 
 - For Secret Manager: `roles/secretmanager.admin` or more granular permissions
 - For Create projects: `roles/resourcemanager.projectCreator` or more [granular permissions](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project)

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/README.md
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/README.md
@@ -6,7 +6,9 @@ This plugin extends the Backstage Scaffolder Backend with actions for interactin
 
 Currently supported actions:
 
-- `datolabs:gcp:secrets-manager:create` - Create secrets in GCP Secret Manager.
+- `datolabs:gcp:secrets-manager:create` — create secrets in GCP Secret Manager.
+- `datolabs:gcp:project:create` — create a new GCP project under a folder or organization.
+- `datolabs:gcp:bucket:create` — create a new GCS bucket.
 
 ## Installation
 
@@ -42,17 +44,31 @@ Each action accepts the user's Google OAuth access token via either:
 A typical setup:
 
 1. Configure the [Google auth provider](https://backstage.io/docs/auth/google/provider/)
-   in your Backstage backend so users can sign in with Google. See the
-   [`broadinstitute/backstage` reference implementation](https://github.com/broadinstitute/backstage/blob/main/backstage/packages/backend/src/index.ts#L30-L93)
-   for a working example.
-2. In the frontend, request a Google access token with the scopes the
+   in your Backstage backend so users can sign in with Google.
+2. In the Oauth app that you set up in GCP for the auth provider, make sure to add the necessary
+   scopes for the actions you want to use (e.g. `https://www.googleapis.com/auth/cloud-platform`).
+3. Update your app-config.yaml file to include additional scopes in the auth provider configuration:
+
+```yaml
+providers:
+  google:
+    development:
+      clientId:
+        $file: ./secrets/auth-google-client-id
+      clientSecret:
+        $file: ./secrets/auth-google-client-secret
+      additionalScopes:
+        - https://www.googleapis.com/auth/cloud-platform
+```
+
+4. In the frontend, request a Google access token with the scopes the
    action needs (e.g. `https://www.googleapis.com/auth/cloud-platform`)
    using `googleAuthApiRef.getAccessToken(...)` and forward it to the
    scaffolder task as a secret named `googleAccessToken`. This is
    typically done with a custom scaffolder field extension — a working
    copy/paste example is available in
    [`examples/field-extension`](../../examples/field-extension).
-3. The action will then authenticate to GCP as the signed-in user.
+5. The action will then authenticate to GCP as the signed-in user.
 
 Make sure the user has the necessary IAM roles for the action being
 invoked.
@@ -95,7 +111,17 @@ roles for the actions you plan to use:
 - For Secret Manager: `roles/secretmanager.admin` or more granular permissions
 - For Create projects: `roles/resourcemanager.projectCreator` or more [granular permissions](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project)
 - For Create GCS Buckets: `roles/storage.admin` or more [granular permissions](https://cloud.google.com/storage/docs/access-control/iam-roles)
-- For Create GCS Bucket IAM Policy: `roles/storage.admin` or more [granular permissions](https://cloud.google.com/storage/docs/access-control/iam-roles)
+
+#### Verifying which credential the action used
+
+Each action logs which credential source it ended up using when it runs.
+Look for one of these lines in the Scaffolder task log:
+
+- `using Google OAuth access token from secrets.googleAccessToken (length=…)`
+- `using Google OAuth access token from action input (length=…)`
+- `no Google OAuth access token provided; falling back to Application Default Credentials`
+
+The token value itself is never logged.
 
 ## Usage Examples
 

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/package.json
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/package.json
@@ -30,10 +30,12 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-plugin-api": "^1.1.1",
+    "@backstage/backend-plugin-api": "^1.9.0",
     "@backstage/plugin-scaffolder-node": "^0.6.3",
     "@google-cloud/resource-manager": "^6.0.0",
-    "@google-cloud/secret-manager": "^5.6.0"
+    "@google-cloud/secret-manager": "^5.6.0",
+    "@google-cloud/storage": "^7.0.0",
+    "google-auth-library": "^9.0.0"
   },
   "devDependencies": {
     "@backstage/backend-common": "^0.25.0",

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/package.json
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/package.json
@@ -30,7 +30,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-plugin-api": "^1.9.0",
+    "@backstage/backend-plugin-api": "^1.1.1",
     "@backstage/plugin-scaffolder-node": "^0.6.3",
     "@google-cloud/resource-manager": "^6.0.0",
     "@google-cloud/secret-manager": "^5.6.0",

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/auth.test.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/auth.test.ts
@@ -26,16 +26,7 @@ describe('resolveGoogleAccessToken', () => {
     expect(resolveGoogleAccessToken({})).toEqual({ source: 'none' });
   });
 
-  it('prefers the explicit token over the secret', () => {
-    expect(
-      resolveGoogleAccessToken(
-        { googleAccessToken: 'from-secret' },
-        'explicit',
-      ),
-    ).toEqual({ token: 'explicit', source: 'input' });
-  });
-
-  it('falls back to secrets.googleAccessToken', () => {
+  it('reads secrets.googleAccessToken', () => {
     expect(
       resolveGoogleAccessToken({ googleAccessToken: 'from-secret' }),
     ).toEqual({ token: 'from-secret', source: 'secret' });
@@ -43,7 +34,7 @@ describe('resolveGoogleAccessToken', () => {
 });
 
 describe('buildGoogleClientOptions', () => {
-  it('returns empty options when no token is supplied', () => {
+  it('returns empty options when neither token nor projectId is supplied', () => {
     expect(buildGoogleClientOptions()).toEqual({});
     expect(buildGoogleClientOptions(undefined)).toEqual({});
   });
@@ -53,26 +44,26 @@ describe('buildGoogleClientOptions', () => {
     expect(opts.authClient).toBeDefined();
     expect(opts.authClient!.credentials.access_token).toBe('abc123');
   });
+
+  it('includes projectId when supplied, so the client does not auto-detect one', () => {
+    expect(buildGoogleClientOptions(undefined, 'my-proj')).toEqual({
+      projectId: 'my-proj',
+    });
+    const opts = buildGoogleClientOptions('abc123', 'my-proj');
+    expect(opts.projectId).toBe('my-proj');
+    expect(opts.authClient).toBeDefined();
+  });
 });
 
 describe('describeGoogleAccessToken', () => {
-  it('describes an input-sourced token without leaking the value', () => {
+  it('describes a secret-sourced token without leaking the value', () => {
     const msg = describeGoogleAccessToken({
       token: 'super-secret',
-      source: 'input',
-    });
-    expect(msg).toContain('action input');
-    expect(msg).toContain('length=12');
-    expect(msg).not.toContain('super-secret');
-  });
-
-  it('describes a secret-sourced token', () => {
-    const msg = describeGoogleAccessToken({
-      token: 'tok',
       source: 'secret',
     });
     expect(msg).toContain('secrets.googleAccessToken');
-    expect(msg).toContain('length=3');
+    expect(msg).toContain('length=12');
+    expect(msg).not.toContain('super-secret');
   });
 
   it('describes the ADC fallback when no token is present', () => {

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/auth.test.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/auth.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 Datolabs, MB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  buildGoogleClientOptions,
+  describeGoogleAccessToken,
+  resolveGoogleAccessToken,
+} from './auth';
+
+describe('resolveGoogleAccessToken', () => {
+  it('returns source=none when nothing is provided', () => {
+    expect(resolveGoogleAccessToken(undefined)).toEqual({ source: 'none' });
+    expect(resolveGoogleAccessToken({})).toEqual({ source: 'none' });
+  });
+
+  it('prefers the explicit token over the secret', () => {
+    expect(
+      resolveGoogleAccessToken(
+        { googleAccessToken: 'from-secret' },
+        'explicit',
+      ),
+    ).toEqual({ token: 'explicit', source: 'input' });
+  });
+
+  it('falls back to secrets.googleAccessToken', () => {
+    expect(
+      resolveGoogleAccessToken({ googleAccessToken: 'from-secret' }),
+    ).toEqual({ token: 'from-secret', source: 'secret' });
+  });
+});
+
+describe('buildGoogleClientOptions', () => {
+  it('returns empty options when no token is supplied', () => {
+    expect(buildGoogleClientOptions()).toEqual({});
+    expect(buildGoogleClientOptions(undefined)).toEqual({});
+  });
+
+  it('returns an OAuth2 client populated with the token', () => {
+    const opts = buildGoogleClientOptions('abc123');
+    expect(opts.authClient).toBeDefined();
+    expect(opts.authClient!.credentials.access_token).toBe('abc123');
+  });
+});
+
+describe('describeGoogleAccessToken', () => {
+  it('describes an input-sourced token without leaking the value', () => {
+    const msg = describeGoogleAccessToken({
+      token: 'super-secret',
+      source: 'input',
+    });
+    expect(msg).toContain('action input');
+    expect(msg).toContain('length=12');
+    expect(msg).not.toContain('super-secret');
+  });
+
+  it('describes a secret-sourced token', () => {
+    const msg = describeGoogleAccessToken({
+      token: 'tok',
+      source: 'secret',
+    });
+    expect(msg).toContain('secrets.googleAccessToken');
+    expect(msg).toContain('length=3');
+  });
+
+  it('describes the ADC fallback when no token is present', () => {
+    expect(describeGoogleAccessToken({ source: 'none' })).toMatch(
+      /Application Default Credentials/,
+    );
+  });
+});

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/auth.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/auth.ts
@@ -15,7 +15,7 @@
  */
 import { UserRefreshClient } from 'google-auth-library';
 
-export type GoogleAccessTokenSource = 'input' | 'secret' | 'none';
+export type GoogleAccessTokenSource = 'secret' | 'none';
 
 export interface ResolvedGoogleAccessToken {
   token?: string;
@@ -23,22 +23,17 @@ export interface ResolvedGoogleAccessToken {
 }
 
 /**
- * Resolve a Google OAuth2 access token from the available scaffolder
- * action context. Lookup order:
- *   1. An explicit `token` value (e.g. from action input).
- *   2. `ctx.secrets.googleAccessToken` (recommended way to forward the
- *      end user's Google OAuth token from the Scaffolder UI).
+ * Resolve a Google OAuth2 access token from the scaffolder action
+ * context. Reads `ctx.secrets.googleAccessToken` — the secrets channel
+ * is the only safe path, since scaffolder secrets stay in memory and
+ * are not persisted to the task database (unlike action inputs).
  *
  * Returns `{ source: 'none' }` when no token is available, which signals
  * callers to fall back to Application Default Credentials (ADC).
  */
 export function resolveGoogleAccessToken(
   secrets: Record<string, string> | undefined,
-  explicitToken?: string,
 ): ResolvedGoogleAccessToken {
-  if (explicitToken) {
-    return { token: explicitToken, source: 'input' };
-  }
   if (secrets?.googleAccessToken) {
     return { token: secrets.googleAccessToken, source: 'secret' };
   }
@@ -47,9 +42,15 @@ export function resolveGoogleAccessToken(
 
 /**
  * Build options for a Google Cloud client library that will authenticate
- * as the supplied user access token. When no token is provided, returns
- * an empty object so the client falls back to Application Default
- * Credentials.
+ * as the supplied user access token. When no token is provided, the
+ * client falls back to Application Default Credentials.
+ *
+ * `projectId` should be passed whenever the caller already knows the
+ * target project. With a user OAuth token the auth client has no
+ * associated project, so GCP client libraries fail to auto-detect one
+ * (see `findAndCacheProjectId` in `google-auth-library`). Passing it
+ * explicitly avoids the lookup and the "Unable to detect a Project Id"
+ * error.
  *
  * Uses `UserRefreshClient` (a subclass of `OAuth2Client`) so the
  * resulting auth client is compatible with all three GCP client
@@ -66,16 +67,65 @@ export function resolveGoogleAccessToken(
  * TypeScript declarations conflict, so a single concrete type cannot
  * satisfy all three call sites simultaneously.
  */
-export function buildGoogleClientOptions(token?: string): {
+export function buildGoogleClientOptions(
+  token?: string,
+  projectId?: string,
+): {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   authClient?: any;
+  projectId?: string;
 } {
-  if (!token) {
-    return {};
+  const opts: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    authClient?: any;
+    projectId?: string;
+  } = {};
+  if (projectId) {
+    opts.projectId = projectId;
   }
-  const authClient = new UserRefreshClient();
-  authClient.setCredentials({ access_token: token });
-  return { authClient };
+  if (token) {
+    const authClient = new UserRefreshClient();
+    authClient.setCredentials({ access_token: token });
+    // The hoisted `google-auth-library` (v9) returns a plain object from
+    // `getRequestHeaders()`. The copy bundled with
+    // `@google-cloud/resource-manager` (v10-rc) iterates that result via
+    // `headers.forEach(value, key)`, which fails on a plain object with
+    // "headers.forEach is not a function". We can't just convert the
+    // result to a `Headers` instance — the REST-based storage client
+    // still uses the v9 contract and reads headers via
+    // `Object.entries(...)`, which would yield nothing from a `Headers`.
+    // Instead, attach a non-enumerable `forEach` to the plain object so
+    // both consumers work.
+    const original = authClient.getRequestHeaders.bind(authClient);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (authClient as any).getRequestHeaders = async (...args: any[]) => {
+      const result = await original(...(args as []));
+      if (
+        result &&
+        typeof (result as { forEach?: unknown }).forEach === 'function'
+      ) {
+        return result;
+      }
+      const headers = result as Record<string, unknown>;
+      Object.defineProperty(headers, 'forEach', {
+        value: (
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          cb: (value: unknown, key: string, parent: any) => void,
+          thisArg?: unknown,
+        ) => {
+          for (const key of Object.keys(headers)) {
+            cb.call(thisArg, headers[key], key, headers);
+          }
+        },
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+      return result;
+    };
+    opts.authClient = authClient;
+  }
+  return opts;
 }
 
 /**
@@ -86,10 +136,6 @@ export function describeGoogleAccessToken(
   resolved: ResolvedGoogleAccessToken,
 ): string {
   switch (resolved.source) {
-    case 'input':
-      return `using Google OAuth access token from action input (length=${
-        resolved.token?.length ?? 0
-      })`;
     case 'secret':
       return `using Google OAuth access token from secrets.googleAccessToken (length=${
         resolved.token?.length ?? 0

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/auth.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/auth.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Datolabs, MB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { OAuth2Client } from 'google-auth-library';
+
+export type GoogleAccessTokenSource = 'input' | 'secret' | 'none';
+
+export interface ResolvedGoogleAccessToken {
+  token?: string;
+  source: GoogleAccessTokenSource;
+}
+
+/**
+ * Resolve a Google OAuth2 access token from the available scaffolder
+ * action context. Lookup order:
+ *   1. An explicit `token` value (e.g. from action input).
+ *   2. `ctx.secrets.googleAccessToken` (recommended way to forward the
+ *      end user's Google OAuth token from the Scaffolder UI).
+ *
+ * Returns `{ source: 'none' }` when no token is available, which signals
+ * callers to fall back to Application Default Credentials (ADC).
+ */
+export function resolveGoogleAccessToken(
+  secrets: Record<string, string> | undefined,
+  explicitToken?: string,
+): ResolvedGoogleAccessToken {
+  if (explicitToken) {
+    return { token: explicitToken, source: 'input' };
+  }
+  if (secrets?.googleAccessToken) {
+    return { token: secrets.googleAccessToken, source: 'secret' };
+  }
+  return { source: 'none' };
+}
+
+/**
+ * Build options for a Google Cloud client library that will authenticate
+ * as the supplied user access token. When no token is provided, returns
+ * an empty object so the client falls back to Application Default
+ * Credentials.
+ */
+export function buildGoogleClientOptions(token?: string): {
+  authClient?: OAuth2Client;
+} {
+  if (!token) {
+    return {};
+  }
+  const authClient = new OAuth2Client();
+  authClient.setCredentials({ access_token: token });
+  return { authClient };
+}
+
+/**
+ * Produce a human-readable, secret-safe description of a resolved token
+ * for log output. Never logs the token value itself.
+ */
+export function describeGoogleAccessToken(
+  resolved: ResolvedGoogleAccessToken,
+): string {
+  switch (resolved.source) {
+    case 'input':
+      return `using Google OAuth access token from action input (length=${
+        resolved.token?.length ?? 0
+      })`;
+    case 'secret':
+      return `using Google OAuth access token from secrets.googleAccessToken (length=${
+        resolved.token?.length ?? 0
+      })`;
+    case 'none':
+    default:
+      return 'no Google OAuth access token provided; falling back to Application Default Credentials';
+  }
+}

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/auth.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/auth.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { OAuth2Client } from 'google-auth-library';
+import { UserRefreshClient } from 'google-auth-library';
 
 export type GoogleAccessTokenSource = 'input' | 'secret' | 'none';
 
@@ -50,14 +50,30 @@ export function resolveGoogleAccessToken(
  * as the supplied user access token. When no token is provided, returns
  * an empty object so the client falls back to Application Default
  * Credentials.
+ *
+ * Uses `UserRefreshClient` (a subclass of `OAuth2Client`) so the
+ * resulting auth client is compatible with all three GCP client
+ * families used by this plugin:
+ *   - REST-based `@google-cloud/storage`
+ *   - gRPC/gax-based `@google-cloud/secret-manager`
+ *   - gRPC/gax-based `@google-cloud/resource-manager`
+ *
+ * The return type for `authClient` is intentionally widened to `any`
+ * because each of those packages bundles its *own* copy of
+ * `google-auth-library` with subtly different `UserRefreshClient`
+ * declarations (e.g. v10-rc adds `addUserProjectAndAuthHeaders`).
+ * The objects are interchangeable at runtime — only the duplicated
+ * TypeScript declarations conflict, so a single concrete type cannot
+ * satisfy all three call sites simultaneously.
  */
 export function buildGoogleClientOptions(token?: string): {
-  authClient?: OAuth2Client;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authClient?: any;
 } {
   if (!token) {
     return {};
   }
-  const authClient = new OAuth2Client();
+  const authClient = new UserRefreshClient();
   authClient.setCredentials({ access_token: token });
   return { authClient };
 }

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/resource-manager/create.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/resource-manager/create.ts
@@ -31,7 +31,6 @@ export function createGcpProjectCreateAction(): TemplateAction<{
   labels?: Record<string, string>;
   tags?: Record<string, string>;
   projectId: string;
-  token?: string;
 }> {
   return createTemplateAction({
     id: 'datolabs:gcp:project:create',
@@ -75,18 +74,12 @@ export function createGcpProjectCreateAction(): TemplateAction<{
             description: 'The GCP project ID',
             type: 'string',
           },
-          token: {
-            title: 'Google OAuth access token',
-            description:
-              'Optional Google OAuth access token to authenticate the request. If omitted, `secrets.googleAccessToken` is used, otherwise Application Default Credentials are used.',
-            type: 'string',
-          },
         },
       },
     },
     async handler(ctx) {
-      const { displayName, parent, labels, projectId, tags, token } = ctx.input;
-      const resolved = resolveGoogleAccessToken(ctx.secrets, token);
+      const { displayName, parent, labels, projectId, tags } = ctx.input;
+      const resolved = resolveGoogleAccessToken(ctx.secrets);
       ctx.logger.info(describeGoogleAccessToken(resolved));
       const resourcemanagerClient = new ProjectsClient(
         buildGoogleClientOptions(resolved.token),

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/resource-manager/create.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/resource-manager/create.ts
@@ -19,6 +19,11 @@ import {
 } from '@backstage/plugin-scaffolder-node';
 // import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
 import { ProjectsClient } from '@google-cloud/resource-manager';
+import {
+  buildGoogleClientOptions,
+  describeGoogleAccessToken,
+  resolveGoogleAccessToken,
+} from '../auth';
 
 export function createGcpProjectCreateAction(): TemplateAction<{
   displayName: string;
@@ -26,6 +31,7 @@ export function createGcpProjectCreateAction(): TemplateAction<{
   labels?: Record<string, string>;
   tags?: Record<string, string>;
   projectId: string;
+  token?: string;
 }> {
   return createTemplateAction({
     id: 'datolabs:gcp:project:create',
@@ -69,12 +75,22 @@ export function createGcpProjectCreateAction(): TemplateAction<{
             description: 'The GCP project ID',
             type: 'string',
           },
+          token: {
+            title: 'Google OAuth access token',
+            description:
+              'Optional Google OAuth access token to authenticate the request. If omitted, `secrets.googleAccessToken` is used, otherwise Application Default Credentials are used.',
+            type: 'string',
+          },
         },
       },
     },
     async handler(ctx) {
-      const resourcemanagerClient = new ProjectsClient();
-      const { displayName, parent, labels, projectId, tags } = ctx.input;
+      const { displayName, parent, labels, projectId, tags, token } = ctx.input;
+      const resolved = resolveGoogleAccessToken(ctx.secrets, token);
+      ctx.logger.info(describeGoogleAccessToken(resolved));
+      const resourcemanagerClient = new ProjectsClient(
+        buildGoogleClientOptions(resolved.token),
+      );
 
       try {
         const request = {

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/secrets-manager/create.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/secrets-manager/create.ts
@@ -18,12 +18,18 @@ import {
   TemplateAction,
 } from '@backstage/plugin-scaffolder-node';
 import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
+import {
+  buildGoogleClientOptions,
+  describeGoogleAccessToken,
+  resolveGoogleAccessToken,
+} from '../auth';
 
 export function createGcpSecretsManagerCreateAction(): TemplateAction<{
   name: string;
   value: string;
   labels?: Record<string, string>;
   project: string;
+  token?: string;
 }> {
   return createTemplateAction({
     id: 'datolabs:gcp:secrets-manager:create',
@@ -57,12 +63,22 @@ export function createGcpSecretsManagerCreateAction(): TemplateAction<{
             description: 'The GCP project ID where the secret will be created',
             type: 'string',
           },
+          token: {
+            title: 'Google OAuth access token',
+            description:
+              'Optional Google OAuth access token to authenticate the request. If omitted, `secrets.googleAccessToken` is used, otherwise Application Default Credentials are used.',
+            type: 'string',
+          },
         },
       },
     },
     async handler(ctx) {
-      const client = new SecretManagerServiceClient();
-      const { name, value, labels, project } = ctx.input;
+      const { name, value, labels, project, token } = ctx.input;
+      const resolved = resolveGoogleAccessToken(ctx.secrets, token);
+      ctx.logger.info(describeGoogleAccessToken(resolved));
+      const client = new SecretManagerServiceClient(
+        buildGoogleClientOptions(resolved.token),
+      );
 
       try {
         const [secret] = await client.createSecret({

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/secrets-manager/create.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/secrets-manager/create.ts
@@ -29,7 +29,6 @@ export function createGcpSecretsManagerCreateAction(): TemplateAction<{
   value: string;
   labels?: Record<string, string>;
   project: string;
-  token?: string;
 }> {
   return createTemplateAction({
     id: 'datolabs:gcp:secrets-manager:create',
@@ -63,21 +62,15 @@ export function createGcpSecretsManagerCreateAction(): TemplateAction<{
             description: 'The GCP project ID where the secret will be created',
             type: 'string',
           },
-          token: {
-            title: 'Google OAuth access token',
-            description:
-              'Optional Google OAuth access token to authenticate the request. If omitted, `secrets.googleAccessToken` is used, otherwise Application Default Credentials are used.',
-            type: 'string',
-          },
         },
       },
     },
     async handler(ctx) {
-      const { name, value, labels, project, token } = ctx.input;
-      const resolved = resolveGoogleAccessToken(ctx.secrets, token);
+      const { name, value, labels, project } = ctx.input;
+      const resolved = resolveGoogleAccessToken(ctx.secrets);
       ctx.logger.info(describeGoogleAccessToken(resolved));
       const client = new SecretManagerServiceClient(
-        buildGoogleClientOptions(resolved.token),
+        buildGoogleClientOptions(resolved.token, project),
       );
 
       try {

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/storage/create.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/storage/create.ts
@@ -32,7 +32,6 @@ export function createGcpGcsBucketCreateAction(): TemplateAction<{
   location: string;
   storageClass: string;
   versioning: boolean;
-  token?: string;
 }> {
   return createTemplateAction({
     id: 'datolabs:gcp:bucket:create',
@@ -89,12 +88,6 @@ export function createGcpGcsBucketCreateAction(): TemplateAction<{
             required: false,
             default: false,
           },
-          token: {
-            title: 'Google OAuth access token',
-            description:
-              'Optional Google OAuth access token to authenticate the request. If omitted, `secrets.googleAccessToken` is used, otherwise Application Default Credentials are used.',
-            type: 'string',
-          },
         },
       },
     },
@@ -107,12 +100,11 @@ export function createGcpGcsBucketCreateAction(): TemplateAction<{
         project,
         storageClass = 'standard',
         versioning = false,
-        token,
       } = ctx.input;
-      const resolved = resolveGoogleAccessToken(ctx.secrets, token);
+      const resolved = resolveGoogleAccessToken(ctx.secrets);
       ctx.logger.info(describeGoogleAccessToken(resolved));
       const storageClient = new Storage(
-        buildGoogleClientOptions(resolved.token),
+        buildGoogleClientOptions(resolved.token, project),
       );
 
       try {

--- a/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/storage/create.ts
+++ b/workspaces/scaffolder-backend-module-gcp/plugins/scaffolder-backend-module-gcp/src/actions/storage/create.ts
@@ -18,6 +18,11 @@ import {
   TemplateAction,
 } from '@backstage/plugin-scaffolder-node';
 import { Storage } from '@google-cloud/storage';
+import {
+  buildGoogleClientOptions,
+  describeGoogleAccessToken,
+  resolveGoogleAccessToken,
+} from '../auth';
 
 export function createGcpGcsBucketCreateAction(): TemplateAction<{
   project: string;
@@ -27,6 +32,7 @@ export function createGcpGcsBucketCreateAction(): TemplateAction<{
   location: string;
   storageClass: string;
   versioning: boolean;
+  token?: string;
 }> {
   return createTemplateAction({
     id: 'datolabs:gcp:bucket:create',
@@ -83,11 +89,16 @@ export function createGcpGcsBucketCreateAction(): TemplateAction<{
             required: false,
             default: false,
           },
+          token: {
+            title: 'Google OAuth access token',
+            description:
+              'Optional Google OAuth access token to authenticate the request. If omitted, `secrets.googleAccessToken` is used, otherwise Application Default Credentials are used.',
+            type: 'string',
+          },
         },
       },
     },
     async handler(ctx) {
-      const storageClient = new Storage();
       const {
         autoClass = false,
         bucketName,
@@ -96,7 +107,13 @@ export function createGcpGcsBucketCreateAction(): TemplateAction<{
         project,
         storageClass = 'standard',
         versioning = false,
+        token,
       } = ctx.input;
+      const resolved = resolveGoogleAccessToken(ctx.secrets, token);
+      ctx.logger.info(describeGoogleAccessToken(resolved));
+      const storageClient = new Storage(
+        buildGoogleClientOptions(resolved.token),
+      );
 
       try {
         const request = {

--- a/workspaces/scaffolder-backend-module-gcp/yarn.lock
+++ b/workspaces/scaffolder-backend-module-gcp/yarn.lock
@@ -3009,25 +3009,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^1.0.0, @backstage/backend-plugin-api@npm:^1.1.1, @backstage/backend-plugin-api@npm:^1.9.0, @backstage/backend-plugin-api@npm:^1.9.1":
-  version: 1.9.1
-  resolution: "@backstage/backend-plugin-api@npm:1.9.1"
+"@backstage/backend-plugin-api@npm:^1.0.0, @backstage/backend-plugin-api@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@backstage/backend-plugin-api@npm:1.1.1"
   dependencies:
-    "@backstage/cli-common": "npm:^0.2.2"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/plugin-auth-node": "npm:^0.7.1"
-    "@backstage/plugin-permission-common": "npm:^0.9.9"
-    "@backstage/plugin-permission-node": "npm:^0.11.0"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/cli-common": "npm:^0.1.15"
+    "@backstage/config": "npm:^1.3.2"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/plugin-auth-node": "npm:^0.5.6"
+    "@backstage/plugin-permission-common": "npm:^0.8.4"
+    "@backstage/types": "npm:^1.2.1"
     "@types/express": "npm:^4.17.6"
-    "@types/json-schema": "npm:^7.0.6"
     "@types/luxon": "npm:^3.0.0"
-    json-schema: "npm:^0.4.0"
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10c0/85a45d20524e141685ad8136c2a857a46fe835a83f18ba8b05b0c252d43440adc3e299562e44075d3a86f271385a0d086d6dd97c6fd7578008b94e39600b8843
+  checksum: 10c0/cf19449f4046a3096906ec7d434f53198257fa3a48c2913b000fe7b3e992d95c05b6a5424573ebf4d81d18ba402388538a15a843e34e2ff56189b76d441d01b6
   languageName: node
   linkType: hard
 
@@ -3068,31 +3064,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:^1.15.1, @backstage/catalog-client@npm:^1.9.1":
-  version: 1.15.1
-  resolution: "@backstage/catalog-client@npm:1.15.1"
+"@backstage/catalog-client@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@backstage/catalog-client@npm:1.9.1"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.9.0"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/filter-predicates": "npm:^0.1.3"
+    "@backstage/catalog-model": "npm:^1.7.3"
+    "@backstage/errors": "npm:^1.2.7"
     cross-fetch: "npm:^4.0.0"
-    lodash: "npm:^4.17.21"
     uri-template: "npm:^2.0.0"
-  checksum: 10c0/997d4eaa144d5f951d6185c938cb12a270b6050023013cfff4284833b822fa9be58c10a81815b872fa91ce3b9d3aed6757c5cc4c3e8f2e00ab7c31eee690f7fc
+  checksum: 10c0/8b9a9e61026418e4ba85d5e8129e2ba0b0e39f526b94a5f0e6d0b862770c5304f1677e028c444e52fd8fd1d14193c5effce022996264fd3d3365c5d8b8e45551
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@npm:^1.7.3, @backstage/catalog-model@npm:^1.9.0":
-  version: 1.9.0
-  resolution: "@backstage/catalog-model@npm:1.9.0"
+"@backstage/catalog-model@npm:^1.7.3":
+  version: 1.7.3
+  resolution: "@backstage/catalog-model@npm:1.7.3"
   dependencies:
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/types": "npm:^1.2.1"
     ajv: "npm:^8.10.0"
-    ajv-errors: "npm:^3.0.0"
     lodash: "npm:^4.17.21"
-    zod: "npm:^3.25.76"
-  checksum: 10c0/05ae984123b56d830861f23c428c11e2e62b273757fcef318afe26e361f09c2bc87976dfea602bf0933fafa82955bc31e6ac0f4e8ab7bcaa583ea4755da4239f
+  checksum: 10c0/6bd3644be089ea5bb980a40426663b609d5a224d1b27a6967a335d497d3591a6463cfd0c5ab27151bb4a8727cd0f881c25423dcb993352b0eb60fe1c7e55f1be
   languageName: node
   linkType: hard
 
@@ -3100,18 +3092,6 @@ __metadata:
   version: 0.1.15
   resolution: "@backstage/cli-common@npm:0.1.15"
   checksum: 10c0/6155d7343814dbe1bc84073d5cdf73e00f379ffc7880a166ad8843443e7dedbe0887a389df5010b909832e8f232d4283a81b2abbda992130a865286445643ff9
-  languageName: node
-  linkType: hard
-
-"@backstage/cli-common@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "@backstage/cli-common@npm:0.2.2"
-  dependencies:
-    "@backstage/errors": "npm:^1.3.1"
-    cross-spawn: "npm:^7.0.3"
-    global-agent: "npm:^3.0.0"
-    undici: "npm:^7.24.5"
-  checksum: 10c0/b83af32489662c1af7009d4a4965e5251cbe7e6bd12e5e14f2951e25d953872cba5802d9e6b780d0c93be95cdd9712e3ababeb2e97e34632b5cda6729f92a46d
   languageName: node
   linkType: hard
 
@@ -3288,14 +3268,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2, @backstage/config@npm:^1.3.8":
-  version: 1.3.8
-  resolution: "@backstage/config@npm:1.3.8"
+"@backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "@backstage/config@npm:1.3.2"
   dependencies:
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/types": "npm:^1.2.1"
     ms: "npm:^2.1.3"
-  checksum: 10c0/bd9e1fdd7ab8e56a9814a7f67502ed69f9abd0f014dae44d253a6a02c0c6bf844451d037afa991b200fc09d89e7195593bd5a9459357dafd8101dc826e664dec
+  checksum: 10c0/9d3dfac9b359727b727567834c2576cc2af96e149b3a0b45565251b02f2dfda9559ee3719d1eed240f5cae4f6b8bb9babfbffc3a35d2d2d8fbe5c408c41c42e3
   languageName: node
   linkType: hard
 
@@ -3436,13 +3416,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/errors@npm:^1.2.4, @backstage/errors@npm:^1.2.7, @backstage/errors@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "@backstage/errors@npm:1.3.1"
+"@backstage/errors@npm:^1.2.4, @backstage/errors@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "@backstage/errors@npm:1.2.7"
   dependencies:
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/types": "npm:^1.2.1"
     serialize-error: "npm:^8.0.1"
-  checksum: 10c0/b342551f5337f17bcc6d412868f6274509d657cc6037fbb5af96d42156c24c2419e72fd711136e42d05245bd4e5c5d8fe9cd54f89f260d9285a073c28cca0261
+  checksum: 10c0/ce04dccc96c49bf121f1de86a589bbe3a613a32f63546b100a9d074bf2cb79c8ba889e1e7ba39c44c717b1bc7dea7654de85b1229fb7e4106e31dd60327c10c1
   languageName: node
   linkType: hard
 
@@ -3453,19 +3433,6 @@ __metadata:
     "@manypkg/get-packages": "npm:^1.1.3"
     minimatch: "npm:^9.0.0"
   checksum: 10c0/679dc6101f342c29e3eeef36608a1e16d67e41c54ca55a2ee33ba45844e0de4bb29e7f015381ed5906945ecd9483f5c17ba286cb3c45b1717013aa0ed1564c8e
-  languageName: node
-  linkType: hard
-
-"@backstage/filter-predicates@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "@backstage/filter-predicates@npm:0.1.3"
-  dependencies:
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-validation-error: "npm:^4.0.2"
-  checksum: 10c0/73cbf7c1719492b56a18c19494e98df0896cad7838b834ca18df3b184bd599a3bb612b9cb6302a1a69546a2bcfe1056d862772cc91844d124692c5eddf95de18
   languageName: node
   linkType: hard
 
@@ -4044,29 +4011,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "@backstage/plugin-auth-node@npm:0.7.1"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.1"
-    "@backstage/catalog-client": "npm:^1.15.1"
-    "@backstage/catalog-model": "npm:^1.9.0"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
-    "@types/express": "npm:^4.17.6"
-    "@types/passport": "npm:^1.0.3"
-    express: "npm:^4.22.0"
-    jose: "npm:^5.0.0"
-    lodash: "npm:^4.17.21"
-    passport: "npm:^0.7.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
-    zod-validation-error: "npm:^4.0.2"
-  checksum: 10c0/be7103ae77c2b4e8f787782bff9a94f2b582f32c1ee2f5de31aec9f9626a7b45bf55b11d9448499e0eda46d8266ba9e378b1b2275e2ca43df27891391c3526d9
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-auth-react@npm:^0.1.11":
   version: 0.1.11
   resolution: "@backstage/plugin-auth-react@npm:0.1.11"
@@ -4584,37 +4528,6 @@ __metadata:
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
   checksum: 10c0/35d52365c1abb23c6ad167149ab78aad0396b97d5c9e591f5a5e397ea029855a6b88f05060e2215e2480244bec797d92871ad92fa613255eeddd54228c01b7f1
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-permission-common@npm:^0.9.9":
-  version: 0.9.9
-  resolution: "@backstage/plugin-permission-common@npm:0.9.9"
-  dependencies:
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
-    cross-fetch: "npm:^4.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10c0/f06156828391ff59b98c2e65d7943503fd1d18d9fd0b22b9df9bbbdeff90469233be1949d22acc9a7ca148c493ff52d2ecba78533702b60d208348c55eb9c720
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-permission-node@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@backstage/plugin-permission-node@npm:0.11.0"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.1"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/plugin-permission-common": "npm:^0.9.9"
-    "@types/express": "npm:^4.17.6"
-    express: "npm:^4.22.0"
-    express-promise-router: "npm:^4.1.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10c0/79db42a485e865738e88ebc9625c4b925e4c93b1639af5ba842468c29b80fdf7080361484da30f926d149634461f64a32b456cf746aec58c5cab8f7618721b1e
   languageName: node
   linkType: hard
 
@@ -5561,10 +5474,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/types@npm:^1.1.1, @backstage/types@npm:^1.2.1, @backstage/types@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "@backstage/types@npm:1.2.2"
-  checksum: 10c0/3c947cf83c058a56b0cfd90d91483e9a5c1c913f7978a0d5a3c0fd9b502d08e9bdf279afba626826eee84159e698ee4cdaa70040789ac47fc8a25df9f1925612
+"@backstage/types@npm:^1.1.1, @backstage/types@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@backstage/types@npm:1.2.1"
+  checksum: 10c0/e7ed5ee0c4e6afa997a3885b7851ce51fc8c1c99cec98a2724da79dbc626f3f9055c5c72f097a2e2f762293e74ecd6b5d30617c27c3b27aa9a63a436f07b576d
   languageName: node
   linkType: hard
 
@@ -5989,7 +5902,7 @@ __metadata:
   resolution: "@datolabs/plugin-scaffolder-backend-module-gcp@workspace:plugins/scaffolder-backend-module-gcp"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:^1.9.0"
+    "@backstage/backend-plugin-api": "npm:^1.1.1"
     "@backstage/cli": "npm:^0.29.6"
     "@backstage/plugin-scaffolder-node": "npm:^0.6.3"
     "@backstage/plugin-scaffolder-node-test-utils": "npm:^0.1.18"
@@ -15274,23 +15187,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:^1.15.2, body-parser@npm:~1.20.5":
-  version: 1.20.5
-  resolution: "body-parser@npm:1.20.5"
+"body-parser@npm:1.20.3, body-parser@npm:^1.15.2":
+  version: 1.20.3
+  resolution: "body-parser@npm:1.20.3"
   dependencies:
-    bytes: "npm:~3.1.2"
+    bytes: "npm:3.1.2"
     content-type: "npm:~1.0.5"
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
-    destroy: "npm:~1.2.0"
-    http-errors: "npm:~2.0.1"
-    iconv-lite: "npm:~0.4.24"
-    on-finished: "npm:~2.4.1"
-    qs: "npm:~6.15.1"
-    raw-body: "npm:~2.5.3"
+    destroy: "npm:1.2.0"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.4.24"
+    on-finished: "npm:2.4.1"
+    qs: "npm:6.13.0"
+    raw-body: "npm:2.5.2"
     type-is: "npm:~1.6.18"
-    unpipe: "npm:~1.0.0"
-  checksum: 10c0/ad777ca5e4711eae253c93f50fdc4608c60b76a9710d79e5e5b84581c76691e6ad21ecc9158986d9ea2b365df73e403ca33c27a8bccc1a7cfc2ccc248548118d
+    unpipe: "npm:1.0.0"
+  checksum: 10c0/0a9a93b7518f222885498dcecaad528cf010dd109b071bf471c93def4bfe30958b83e03496eb9c1ad4896db543d999bb62be1a3087294162a88cfa1b42c16310
   languageName: node
   linkType: hard
 
@@ -15603,7 +15516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:3.1.2, bytes@npm:~3.1.2":
+"bytes@npm:3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
@@ -16545,7 +16458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:~0.5.2, content-disposition@npm:~0.5.4":
+"content-disposition@npm:0.5.4, content-disposition@npm:~0.5.2":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
   dependencies:
@@ -16592,14 +16505,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie-signature@npm:1.0.7, cookie-signature@npm:~1.0.6":
+"cookie-signature@npm:1.0.7":
   version: 1.0.7
   resolution: "cookie-signature@npm:1.0.7"
   checksum: 10c0/e7731ad2995ae2efeed6435ec1e22cdd21afef29d300c27281438b1eab2bae04ef0d1a203928c0afec2cee72aa36540b8747406ebe308ad23c8e8cc3c26c9c51
   languageName: node
   linkType: hard
 
-"cookie@npm:0.7.2, cookie@npm:^0.7.0, cookie@npm:~0.7.1, cookie@npm:~0.7.2":
+"cookie@npm:0.7.1":
+  version: 0.7.1
+  resolution: "cookie@npm:0.7.1"
+  checksum: 10c0/5de60c67a410e7c8dc8a46a4b72eb0fe925871d057c9a5d2c0e8145c4270a4f81076de83410c4d397179744b478e33cd80ccbcc457abf40a9409ad27dcd21dde
+  languageName: node
+  linkType: hard
+
+"cookie@npm:0.7.2, cookie@npm:^0.7.0, cookie@npm:~0.7.2":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
@@ -17663,7 +17583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"destroy@npm:1.2.0, destroy@npm:^1.0.4, destroy@npm:~1.2.0":
+"destroy@npm:1.2.0, destroy@npm:^1.0.4":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
   checksum: 10c0/bd7633942f57418f5a3b80d5cb53898127bcf53e24cdf5d5f4396be471417671f0fee48a4ebe9a1e9defbde2a31280011af58a57e090ff822f589b443ed4e643
@@ -19245,42 +19165,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.14.0, express@npm:^4.17.1, express@npm:^4.18.2, express@npm:^4.19.2, express@npm:^4.21.2, express@npm:^4.22.0":
-  version: 4.22.2
-  resolution: "express@npm:4.22.2"
+"express@npm:^4.14.0, express@npm:^4.17.1, express@npm:^4.18.2, express@npm:^4.19.2, express@npm:^4.21.2":
+  version: 4.21.2
+  resolution: "express@npm:4.21.2"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
-    body-parser: "npm:~1.20.5"
-    content-disposition: "npm:~0.5.4"
+    body-parser: "npm:1.20.3"
+    content-disposition: "npm:0.5.4"
     content-type: "npm:~1.0.4"
-    cookie: "npm:~0.7.1"
-    cookie-signature: "npm:~1.0.6"
+    cookie: "npm:0.7.1"
+    cookie-signature: "npm:1.0.6"
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
     encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     etag: "npm:~1.8.1"
-    finalhandler: "npm:~1.3.1"
-    fresh: "npm:~0.5.2"
-    http-errors: "npm:~2.0.0"
+    finalhandler: "npm:1.3.1"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:2.0.0"
     merge-descriptors: "npm:1.0.3"
     methods: "npm:~1.1.2"
-    on-finished: "npm:~2.4.1"
+    on-finished: "npm:2.4.1"
     parseurl: "npm:~1.3.3"
-    path-to-regexp: "npm:~0.1.12"
+    path-to-regexp: "npm:0.1.12"
     proxy-addr: "npm:~2.0.7"
-    qs: "npm:~6.15.1"
+    qs: "npm:6.13.0"
     range-parser: "npm:~1.2.1"
     safe-buffer: "npm:5.2.1"
-    send: "npm:~0.19.0"
-    serve-static: "npm:~1.16.2"
+    send: "npm:0.19.0"
+    serve-static: "npm:1.16.2"
     setprototypeof: "npm:1.2.0"
-    statuses: "npm:~2.0.1"
+    statuses: "npm:2.0.1"
     type-is: "npm:~1.6.18"
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
-  checksum: 10c0/d06dd4379fd217440b30f8abbe45f0e74931114c1395034f03e7d635196ecdab530d4835a1962a6aa34838d61967dc6f1f77846999bba3032373e9e714222c44
+  checksum: 10c0/38168fd0a32756600b56e6214afecf4fc79ec28eca7f7a91c2ab8d50df4f47562ca3f9dee412da7f5cea6b1a1544b33b40f9f8586dbacfbdada0fe90dbb10a1f
   languageName: node
   linkType: hard
 
@@ -19604,18 +19524,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"finalhandler@npm:~1.3.1":
-  version: 1.3.2
-  resolution: "finalhandler@npm:1.3.2"
+"finalhandler@npm:1.3.1":
+  version: 1.3.1
+  resolution: "finalhandler@npm:1.3.1"
   dependencies:
     debug: "npm:2.6.9"
     encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
-    on-finished: "npm:~2.4.1"
+    on-finished: "npm:2.4.1"
     parseurl: "npm:~1.3.3"
-    statuses: "npm:~2.0.2"
+    statuses: "npm:2.0.1"
     unpipe: "npm:~1.0.0"
-  checksum: 10c0/435a4fd65e4e4e4c71bb5474980090b73c353a123dd415583f67836bdd6516e528cf07298e219a82b94631dee7830eae5eece38d3c178073cf7df4e8c182f413
+  checksum: 10c0/d38035831865a49b5610206a3a9a9aae4e8523cbbcd01175d0480ffbf1278c47f11d89be3ca7f617ae6d94f29cf797546a4619cd84dd109009ef33f12f69019f
   languageName: node
   linkType: hard
 
@@ -19889,7 +19809,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fresh@npm:~0.5.2":
+"fresh@npm:0.5.2, fresh@npm:~0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 10c0/c6d27f3ed86cc5b601404822f31c900dd165ba63fff8152a3ef714e2012e7535027063bc67ded4cb5b3a49fa596495d46cacd9f47d6328459cf570f08b7d9e5a
@@ -21126,6 +21046,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:2.0.0":
+  version: 2.0.0
+  resolution: "http-errors@npm:2.0.0"
+  dependencies:
+    depd: "npm:2.0.0"
+    inherits: "npm:2.0.4"
+    setprototypeof: "npm:1.2.0"
+    statuses: "npm:2.0.1"
+    toidentifier: "npm:1.0.1"
+  checksum: 10c0/fc6f2715fe188d091274b5ffc8b3657bd85c63e969daa68ccb77afb05b071a4b62841acb7a21e417b5539014dff2ebf9550f0b14a9ff126f2734a7c1387f8e19
+  languageName: node
+  linkType: hard
+
 "http-errors@npm:^1.6.3, http-errors@npm:~1.8.0":
   version: 1.8.1
   resolution: "http-errors@npm:1.8.1"
@@ -21148,19 +21081,6 @@ __metadata:
     setprototypeof: "npm:1.1.0"
     statuses: "npm:>= 1.4.0 < 2"
   checksum: 10c0/17ec4046ee974477778bfdd525936c254b872054703ec2caa4d6f099566b8adade636ae6aeeacb39302c5cd6e28fb407ebd937f500f5010d0b6850750414ff78
-  languageName: node
-  linkType: hard
-
-"http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
-  version: 2.0.1
-  resolution: "http-errors@npm:2.0.1"
-  dependencies:
-    depd: "npm:~2.0.0"
-    inherits: "npm:~2.0.4"
-    setprototypeof: "npm:~1.2.0"
-    statuses: "npm:~2.0.2"
-    toidentifier: "npm:~1.0.1"
-  checksum: 10c0/fb38906cef4f5c83952d97661fe14dc156cb59fe54812a42cd448fa57b5c5dfcb38a40a916957737bd6b87aab257c0648d63eb5b6a9ca9f548e105b6072712d4
   languageName: node
   linkType: hard
 
@@ -21336,21 +21256,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
-  languageName: node
-  linkType: hard
-
-"iconv-lite@npm:^0.4.24, iconv-lite@npm:~0.4.24":
-  version: 0.4.24
-  resolution: "iconv-lite@npm:0.4.24"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3"
-  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
   languageName: node
   linkType: hard
 
@@ -26343,7 +26263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:^2.3.0, on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
+"on-finished@npm:2.4.1, on-finished@npm:^2.3.0, on-finished@npm:^2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -27078,6 +26998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:0.1.12":
+  version: 0.1.12
+  resolution: "path-to-regexp@npm:0.1.12"
+  checksum: 10c0/1c6ff10ca169b773f3bba943bbc6a07182e332464704572962d277b900aeee81ac6aa5d060ff9e01149636c30b1f63af6e69dd7786ba6e0ddb39d4dee1f0645b
+  languageName: node
+  linkType: hard
+
 "path-to-regexp@npm:3.3.0":
   version: 3.3.0
   resolution: "path-to-regexp@npm:3.3.0"
@@ -27089,13 +27016,6 @@ __metadata:
   version: 8.2.0
   resolution: "path-to-regexp@npm:8.2.0"
   checksum: 10c0/ef7d0a887b603c0a142fad16ccebdcdc42910f0b14830517c724466ad676107476bba2fe9fffd28fd4c141391ccd42ea426f32bb44c2c82ecaefe10c37b90f5a
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:~0.1.12":
-  version: 0.1.13
-  resolution: "path-to-regexp@npm:0.1.13"
-  checksum: 10c0/1cae3921739c154a8926e136185a10c916f79a249b9072a5001b266d96e193860ca03867e8e8cc808b786862d750f427ed93686bc259355442c3407a62deab1a
   languageName: node
   linkType: hard
 
@@ -28272,12 +28192,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.10.1, qs@npm:^6.10.3, qs@npm:^6.12.2, qs@npm:^6.12.3, qs@npm:^6.9.4, qs@npm:~6.15.1":
-  version: 6.15.2
-  resolution: "qs@npm:6.15.2"
+"qs@npm:6.13.0":
+  version: 6.13.0
+  resolution: "qs@npm:6.13.0"
   dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
+    side-channel: "npm:^1.0.6"
+  checksum: 10c0/62372cdeec24dc83a9fb240b7533c0fdcf0c5f7e0b83343edd7310f0ab4c8205a5e7c56406531f2e47e1b4878a3821d652be4192c841de5b032ca83619d8f860
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.10.1, qs@npm:^6.10.3, qs@npm:^6.12.2, qs@npm:^6.12.3, qs@npm:^6.9.4":
+  version: 6.13.1
+  resolution: "qs@npm:6.13.1"
+  dependencies:
+    side-channel: "npm:^1.0.6"
+  checksum: 10c0/5ef527c0d62ffca5501322f0832d800ddc78eeb00da3b906f1b260ca0492721f8cdc13ee4b8fd8ac314a6ec37b948798c7b603ccc167e954088df392092f160c
   languageName: node
   linkType: hard
 
@@ -28427,15 +28356,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raw-body@npm:^2.4.1, raw-body@npm:~2.5.3":
-  version: 2.5.3
-  resolution: "raw-body@npm:2.5.3"
+"raw-body@npm:2.5.2, raw-body@npm:^2.4.1":
+  version: 2.5.2
+  resolution: "raw-body@npm:2.5.2"
   dependencies:
-    bytes: "npm:~3.1.2"
-    http-errors: "npm:~2.0.1"
-    iconv-lite: "npm:~0.4.24"
-    unpipe: "npm:~1.0.0"
-  checksum: 10c0/449844344fc90547fb994383a494b83300e4f22199f146a79f68d78a199a8f2a923ea9fd29c3be979bfd50291a3884733619ffc15ba02a32e703b612f8d3f74a
+    bytes: "npm:3.1.2"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.4.24"
+    unpipe: "npm:1.0.0"
+  checksum: 10c0/b201c4b66049369a60e766318caff5cb3cc5a900efd89bdac431463822d976ad0670912c931fdbdcf5543207daf6f6833bca57aa116e1661d2ea91e12ca692c4
   languageName: node
   linkType: hard
 
@@ -30126,24 +30055,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"send@npm:~0.19.0, send@npm:~0.19.1":
-  version: 0.19.2
-  resolution: "send@npm:0.19.2"
+"send@npm:0.19.0":
+  version: 0.19.0
+  resolution: "send@npm:0.19.0"
   dependencies:
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
     destroy: "npm:1.2.0"
-    encodeurl: "npm:~2.0.0"
+    encodeurl: "npm:~1.0.2"
     escape-html: "npm:~1.0.3"
     etag: "npm:~1.8.1"
-    fresh: "npm:~0.5.2"
-    http-errors: "npm:~2.0.1"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:2.0.0"
     mime: "npm:1.6.0"
     ms: "npm:2.1.3"
-    on-finished: "npm:~2.4.1"
+    on-finished: "npm:2.4.1"
     range-parser: "npm:~1.2.1"
-    statuses: "npm:~2.0.2"
-  checksum: 10c0/20c2389fe0fdf3fc499938cac598bc32272287e993c4960717381a10de8550028feadfb9076f959a3a3ebdea42e1f690e116f0d16468fa56b9fd41866d3dc267
+    statuses: "npm:2.0.1"
+  checksum: 10c0/ea3f8a67a8f0be3d6bf9080f0baed6d2c51d11d4f7b4470de96a5029c598a7011c497511ccc28968b70ef05508675cebff27da9151dd2ceadd60be4e6cf845e3
   languageName: node
   linkType: hard
 
@@ -30196,15 +30125,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-static@npm:~1.16.2":
-  version: 1.16.3
-  resolution: "serve-static@npm:1.16.3"
+"serve-static@npm:1.16.2":
+  version: 1.16.2
+  resolution: "serve-static@npm:1.16.2"
   dependencies:
     encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     parseurl: "npm:~1.3.3"
-    send: "npm:~0.19.1"
-  checksum: 10c0/36320397a073c71bedf58af48a4a100fe6d93f07459af4d6f08b9a7217c04ce2a4939e0effd842dc7bece93ffcd59eb52f58c4fff2a8e002dc29ae6b219cd42b
+    send: "npm:0.19.0"
+  checksum: 10c0/528fff6f5e12d0c5a391229ad893910709bc51b5705962b09404a1d813857578149b8815f35d3ee5752f44cd378d0f31669d4b1d7e2d11f41e08283d5134bd1f
   languageName: node
   linkType: hard
 
@@ -30272,7 +30201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setprototypeof@npm:1.2.0, setprototypeof@npm:~1.2.0":
+"setprototypeof@npm:1.2.0":
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: 10c0/68733173026766fa0d9ecaeb07f0483f4c2dc70ca376b3b7c40b7cda909f94b0918f6c5ad5ce27a9160bdfb475efaa9d5e705a11d8eaae18f9835d20976028bc
@@ -30359,7 +30288,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4, side-channel@npm:^1.1.0":
+"side-channel@npm:^1.0.4, side-channel@npm:^1.0.6, side-channel@npm:^1.1.0":
   version: 1.1.0
   resolution: "side-channel@npm:1.1.0"
   dependencies:
@@ -30843,17 +30772,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"statuses@npm:2.0.1":
+  version: 2.0.1
+  resolution: "statuses@npm:2.0.1"
+  checksum: 10c0/34378b207a1620a24804ce8b5d230fea0c279f00b18a7209646d5d47e419d1cc23e7cbf33a25a1e51ac38973dc2ac2e1e9c647a8e481ef365f77668d72becfd0
+  languageName: node
+  linkType: hard
+
 "statuses@npm:>= 1.4.0 < 2, statuses@npm:>= 1.5.0 < 2, statuses@npm:^1.5.0, statuses@npm:~1.5.0":
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: 10c0/e433900956357b3efd79b1c547da4d291799ac836960c016d10a98f6a810b1b5c0dcc13b5a7aa609a58239b5190e1ea176ad9221c2157d2fd1c747393e6b2940
-  languageName: node
-  linkType: hard
-
-"statuses@npm:~2.0.1, statuses@npm:~2.0.2":
-  version: 2.0.2
-  resolution: "statuses@npm:2.0.2"
-  checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
   languageName: node
   linkType: hard
 
@@ -31908,7 +31837,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toidentifier@npm:1.0.1, toidentifier@npm:~1.0.1":
+"toidentifier@npm:1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
@@ -32603,13 +32532,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.24.5":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
-  languageName: node
-  linkType: hard
-
 "unicode-canonical-property-names-ecmascript@npm:^2.0.0":
   version: 2.0.1
   resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.1"
@@ -32812,7 +32734,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unpipe@npm:~1.0.0":
+"unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 10c0/193400255bd48968e5c5383730344fbb4fa114cdedfab26e329e50dd2d81b134244bb8a72c6ac1b10ab0281a58b363d06405632c9d49ca9dfd5e90cbd7d0f32c
@@ -34072,12 +33994,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-json-schema@npm:^3.20.4, zod-to-json-schema@npm:^3.21.4, zod-to-json-schema@npm:^3.25.1":
-  version: 3.25.2
-  resolution: "zod-to-json-schema@npm:3.25.2"
+"zod-to-json-schema@npm:^3.20.4, zod-to-json-schema@npm:^3.21.4":
+  version: 3.24.1
+  resolution: "zod-to-json-schema@npm:3.24.1"
   peerDependencies:
-    zod: ^3.25.28 || ^4
-  checksum: 10c0/dd300554393903022487688af14fbda5c719ba8179702bb55b3aa86318830467f0f7beb7d654036975ac963dc4843b72e59636448bfff9a0608f277bb6a14939
+    zod: ^3.24.1
+  checksum: 10c0/dd4e72085003e41a3f532bd00061f27041418a4eb176aa6ce33042db08d141bd37707017ee9117d97738ae3f22fc3e1404ea44e6354634ac5da79d7d3173b4ee
   languageName: node
   linkType: hard
 
@@ -34090,26 +34012,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-validation-error@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "zod-validation-error@npm:4.0.2"
-  peerDependencies:
-    zod: ^3.25.0 || ^4.0.0
-  checksum: 10c0/0ccfec48c46de1be440b719cd02044d4abb89ed0e14c13e637cd55bf29102f67ccdba373f25def0fc7130e5f15025be4d557a7edcc95d5a3811599aade689e1b
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.22.4, zod@npm:^3.25.76":
-  version: 3.25.76
-  resolution: "zod@npm:3.25.76"
-  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.25.76 || ^4.0.0":
-  version: 4.4.3
-  resolution: "zod@npm:4.4.3"
-  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
+"zod@npm:^3.22.4":
+  version: 3.24.1
+  resolution: "zod@npm:3.24.1"
+  checksum: 10c0/0223d21dbaa15d8928fe0da3b54696391d8e3e1e2d0283a1a070b5980a1dbba945ce631c2d1eccc088fdbad0f2dfa40155590bf83732d3ac4fcca2cc9237591b
   languageName: node
   linkType: hard
 

--- a/workspaces/scaffolder-backend-module-gcp/yarn.lock
+++ b/workspaces/scaffolder-backend-module-gcp/yarn.lock
@@ -3009,21 +3009,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^1.0.0, @backstage/backend-plugin-api@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@backstage/backend-plugin-api@npm:1.1.1"
+"@backstage/backend-plugin-api@npm:^1.0.0, @backstage/backend-plugin-api@npm:^1.1.1, @backstage/backend-plugin-api@npm:^1.9.0, @backstage/backend-plugin-api@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@backstage/backend-plugin-api@npm:1.9.1"
   dependencies:
-    "@backstage/cli-common": "npm:^0.1.15"
-    "@backstage/config": "npm:^1.3.2"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-auth-node": "npm:^0.5.6"
-    "@backstage/plugin-permission-common": "npm:^0.8.4"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/cli-common": "npm:^0.2.2"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-auth-node": "npm:^0.7.1"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-permission-node": "npm:^0.11.0"
+    "@backstage/types": "npm:^1.2.2"
     "@types/express": "npm:^4.17.6"
+    "@types/json-schema": "npm:^7.0.6"
     "@types/luxon": "npm:^3.0.0"
+    json-schema: "npm:^0.4.0"
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
-  checksum: 10c0/cf19449f4046a3096906ec7d434f53198257fa3a48c2913b000fe7b3e992d95c05b6a5424573ebf4d81d18ba402388538a15a843e34e2ff56189b76d441d01b6
+    zod: "npm:^3.25.76 || ^4.0.0"
+  checksum: 10c0/85a45d20524e141685ad8136c2a857a46fe835a83f18ba8b05b0c252d43440adc3e299562e44075d3a86f271385a0d086d6dd97c6fd7578008b94e39600b8843
   languageName: node
   linkType: hard
 
@@ -3064,27 +3068,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:^1.9.1":
-  version: 1.9.1
-  resolution: "@backstage/catalog-client@npm:1.9.1"
+"@backstage/catalog-client@npm:^1.15.1, @backstage/catalog-client@npm:^1.9.1":
+  version: 1.15.1
+  resolution: "@backstage/catalog-client@npm:1.15.1"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.3"
     cross-fetch: "npm:^4.0.0"
+    lodash: "npm:^4.17.21"
     uri-template: "npm:^2.0.0"
-  checksum: 10c0/8b9a9e61026418e4ba85d5e8129e2ba0b0e39f526b94a5f0e6d0b862770c5304f1677e028c444e52fd8fd1d14193c5effce022996264fd3d3365c5d8b8e45551
+  checksum: 10c0/997d4eaa144d5f951d6185c938cb12a270b6050023013cfff4284833b822fa9be58c10a81815b872fa91ce3b9d3aed6757c5cc4c3e8f2e00ab7c31eee690f7fc
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@npm:^1.7.3":
-  version: 1.7.3
-  resolution: "@backstage/catalog-model@npm:1.7.3"
+"@backstage/catalog-model@npm:^1.7.3, @backstage/catalog-model@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@backstage/catalog-model@npm:1.9.0"
   dependencies:
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
     ajv: "npm:^8.10.0"
+    ajv-errors: "npm:^3.0.0"
     lodash: "npm:^4.17.21"
-  checksum: 10c0/6bd3644be089ea5bb980a40426663b609d5a224d1b27a6967a335d497d3591a6463cfd0c5ab27151bb4a8727cd0f881c25423dcb993352b0eb60fe1c7e55f1be
+    zod: "npm:^3.25.76"
+  checksum: 10c0/05ae984123b56d830861f23c428c11e2e62b273757fcef318afe26e361f09c2bc87976dfea602bf0933fafa82955bc31e6ac0f4e8ab7bcaa583ea4755da4239f
   languageName: node
   linkType: hard
 
@@ -3092,6 +3100,18 @@ __metadata:
   version: 0.1.15
   resolution: "@backstage/cli-common@npm:0.1.15"
   checksum: 10c0/6155d7343814dbe1bc84073d5cdf73e00f379ffc7880a166ad8843443e7dedbe0887a389df5010b909832e8f232d4283a81b2abbda992130a865286445643ff9
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-common@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@backstage/cli-common@npm:0.2.2"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    cross-spawn: "npm:^7.0.3"
+    global-agent: "npm:^3.0.0"
+    undici: "npm:^7.24.5"
+  checksum: 10c0/b83af32489662c1af7009d4a4965e5251cbe7e6bd12e5e14f2951e25d953872cba5802d9e6b780d0c93be95cdd9712e3ababeb2e97e34632b5cda6729f92a46d
   languageName: node
   linkType: hard
 
@@ -3268,14 +3288,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "@backstage/config@npm:1.3.2"
+"@backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2, @backstage/config@npm:^1.3.8":
+  version: 1.3.8
+  resolution: "@backstage/config@npm:1.3.8"
   dependencies:
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
     ms: "npm:^2.1.3"
-  checksum: 10c0/9d3dfac9b359727b727567834c2576cc2af96e149b3a0b45565251b02f2dfda9559ee3719d1eed240f5cae4f6b8bb9babfbffc3a35d2d2d8fbe5c408c41c42e3
+  checksum: 10c0/bd9e1fdd7ab8e56a9814a7f67502ed69f9abd0f014dae44d253a6a02c0c6bf844451d037afa991b200fc09d89e7195593bd5a9459357dafd8101dc826e664dec
   languageName: node
   linkType: hard
 
@@ -3416,13 +3436,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/errors@npm:^1.2.4, @backstage/errors@npm:^1.2.7":
-  version: 1.2.7
-  resolution: "@backstage/errors@npm:1.2.7"
+"@backstage/errors@npm:^1.2.4, @backstage/errors@npm:^1.2.7, @backstage/errors@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@backstage/errors@npm:1.3.1"
   dependencies:
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/types": "npm:^1.2.2"
     serialize-error: "npm:^8.0.1"
-  checksum: 10c0/ce04dccc96c49bf121f1de86a589bbe3a613a32f63546b100a9d074bf2cb79c8ba889e1e7ba39c44c717b1bc7dea7654de85b1229fb7e4106e31dd60327c10c1
+  checksum: 10c0/b342551f5337f17bcc6d412868f6274509d657cc6037fbb5af96d42156c24c2419e72fd711136e42d05245bd4e5c5d8fe9cd54f89f260d9285a073c28cca0261
   languageName: node
   linkType: hard
 
@@ -3433,6 +3453,19 @@ __metadata:
     "@manypkg/get-packages": "npm:^1.1.3"
     minimatch: "npm:^9.0.0"
   checksum: 10c0/679dc6101f342c29e3eeef36608a1e16d67e41c54ca55a2ee33ba45844e0de4bb29e7f015381ed5906945ecd9483f5c17ba286cb3c45b1717013aa0ed1564c8e
+  languageName: node
+  linkType: hard
+
+"@backstage/filter-predicates@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@backstage/filter-predicates@npm:0.1.3"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10c0/73cbf7c1719492b56a18c19494e98df0896cad7838b834ca18df3b184bd599a3bb612b9cb6302a1a69546a2bcfe1056d862772cc91844d124692c5eddf95de18
   languageName: node
   linkType: hard
 
@@ -4011,6 +4044,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-node@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "@backstage/plugin-auth-node@npm:0.7.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/catalog-client": "npm:^1.15.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/passport": "npm:^1.0.3"
+    express: "npm:^4.22.0"
+    jose: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    passport: "npm:^0.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10c0/be7103ae77c2b4e8f787782bff9a94f2b582f32c1ee2f5de31aec9f9626a7b45bf55b11d9448499e0eda46d8266ba9e378b1b2275e2ca43df27891391c3526d9
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-react@npm:^0.1.11":
   version: 0.1.11
   resolution: "@backstage/plugin-auth-react@npm:0.1.11"
@@ -4528,6 +4584,37 @@ __metadata:
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
   checksum: 10c0/35d52365c1abb23c6ad167149ab78aad0396b97d5c9e591f5a5e397ea029855a6b88f05060e2215e2480244bec797d92871ad92fa613255eeddd54228c01b7f1
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-common@npm:^0.9.9":
+  version: 0.9.9
+  resolution: "@backstage/plugin-permission-common@npm:0.9.9"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    cross-fetch: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10c0/f06156828391ff59b98c2e65d7943503fd1d18d9fd0b22b9df9bbbdeff90469233be1949d22acc9a7ca148c493ff52d2ecba78533702b60d208348c55eb9c720
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-node@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@backstage/plugin-permission-node@npm:0.11.0"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@types/express": "npm:^4.17.6"
+    express: "npm:^4.22.0"
+    express-promise-router: "npm:^4.1.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10c0/79db42a485e865738e88ebc9625c4b925e4c93b1639af5ba842468c29b80fdf7080361484da30f926d149634461f64a32b456cf746aec58c5cab8f7618721b1e
   languageName: node
   linkType: hard
 
@@ -5474,10 +5561,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/types@npm:^1.1.1, @backstage/types@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@backstage/types@npm:1.2.1"
-  checksum: 10c0/e7ed5ee0c4e6afa997a3885b7851ce51fc8c1c99cec98a2724da79dbc626f3f9055c5c72f097a2e2f762293e74ecd6b5d30617c27c3b27aa9a63a436f07b576d
+"@backstage/types@npm:^1.1.1, @backstage/types@npm:^1.2.1, @backstage/types@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@backstage/types@npm:1.2.2"
+  checksum: 10c0/3c947cf83c058a56b0cfd90d91483e9a5c1c913f7978a0d5a3c0fd9b502d08e9bdf279afba626826eee84159e698ee4cdaa70040789ac47fc8a25df9f1925612
   languageName: node
   linkType: hard
 
@@ -5902,7 +5989,7 @@ __metadata:
   resolution: "@datolabs/plugin-scaffolder-backend-module-gcp@workspace:plugins/scaffolder-backend-module-gcp"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:^1.1.1"
+    "@backstage/backend-plugin-api": "npm:^1.9.0"
     "@backstage/cli": "npm:^0.29.6"
     "@backstage/plugin-scaffolder-node": "npm:^0.6.3"
     "@backstage/plugin-scaffolder-node-test-utils": "npm:^0.1.18"
@@ -15187,23 +15274,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.3, body-parser@npm:^1.15.2":
-  version: 1.20.3
-  resolution: "body-parser@npm:1.20.3"
+"body-parser@npm:^1.15.2, body-parser@npm:~1.20.5":
+  version: 1.20.5
+  resolution: "body-parser@npm:1.20.5"
   dependencies:
-    bytes: "npm:3.1.2"
+    bytes: "npm:~3.1.2"
     content-type: "npm:~1.0.5"
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
-    destroy: "npm:1.2.0"
-    http-errors: "npm:2.0.0"
-    iconv-lite: "npm:0.4.24"
-    on-finished: "npm:2.4.1"
-    qs: "npm:6.13.0"
-    raw-body: "npm:2.5.2"
+    destroy: "npm:~1.2.0"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.4.24"
+    on-finished: "npm:~2.4.1"
+    qs: "npm:~6.15.1"
+    raw-body: "npm:~2.5.3"
     type-is: "npm:~1.6.18"
-    unpipe: "npm:1.0.0"
-  checksum: 10c0/0a9a93b7518f222885498dcecaad528cf010dd109b071bf471c93def4bfe30958b83e03496eb9c1ad4896db543d999bb62be1a3087294162a88cfa1b42c16310
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/ad777ca5e4711eae253c93f50fdc4608c60b76a9710d79e5e5b84581c76691e6ad21ecc9158986d9ea2b365df73e403ca33c27a8bccc1a7cfc2ccc248548118d
   languageName: node
   linkType: hard
 
@@ -15516,7 +15603,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:3.1.2":
+"bytes@npm:3.1.2, bytes@npm:~3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
@@ -16458,7 +16545,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:0.5.4, content-disposition@npm:~0.5.2":
+"content-disposition@npm:~0.5.2, content-disposition@npm:~0.5.4":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
   dependencies:
@@ -16505,21 +16592,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie-signature@npm:1.0.7":
+"cookie-signature@npm:1.0.7, cookie-signature@npm:~1.0.6":
   version: 1.0.7
   resolution: "cookie-signature@npm:1.0.7"
   checksum: 10c0/e7731ad2995ae2efeed6435ec1e22cdd21afef29d300c27281438b1eab2bae04ef0d1a203928c0afec2cee72aa36540b8747406ebe308ad23c8e8cc3c26c9c51
   languageName: node
   linkType: hard
 
-"cookie@npm:0.7.1":
-  version: 0.7.1
-  resolution: "cookie@npm:0.7.1"
-  checksum: 10c0/5de60c67a410e7c8dc8a46a4b72eb0fe925871d057c9a5d2c0e8145c4270a4f81076de83410c4d397179744b478e33cd80ccbcc457abf40a9409ad27dcd21dde
-  languageName: node
-  linkType: hard
-
-"cookie@npm:0.7.2, cookie@npm:^0.7.0, cookie@npm:~0.7.2":
+"cookie@npm:0.7.2, cookie@npm:^0.7.0, cookie@npm:~0.7.1, cookie@npm:~0.7.2":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
@@ -17583,7 +17663,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"destroy@npm:1.2.0, destroy@npm:^1.0.4":
+"destroy@npm:1.2.0, destroy@npm:^1.0.4, destroy@npm:~1.2.0":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
   checksum: 10c0/bd7633942f57418f5a3b80d5cb53898127bcf53e24cdf5d5f4396be471417671f0fee48a4ebe9a1e9defbde2a31280011af58a57e090ff822f589b443ed4e643
@@ -19165,42 +19245,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.14.0, express@npm:^4.17.1, express@npm:^4.18.2, express@npm:^4.19.2, express@npm:^4.21.2":
-  version: 4.21.2
-  resolution: "express@npm:4.21.2"
+"express@npm:^4.14.0, express@npm:^4.17.1, express@npm:^4.18.2, express@npm:^4.19.2, express@npm:^4.21.2, express@npm:^4.22.0":
+  version: 4.22.2
+  resolution: "express@npm:4.22.2"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
-    body-parser: "npm:1.20.3"
-    content-disposition: "npm:0.5.4"
+    body-parser: "npm:~1.20.5"
+    content-disposition: "npm:~0.5.4"
     content-type: "npm:~1.0.4"
-    cookie: "npm:0.7.1"
-    cookie-signature: "npm:1.0.6"
+    cookie: "npm:~0.7.1"
+    cookie-signature: "npm:~1.0.6"
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
     encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     etag: "npm:~1.8.1"
-    finalhandler: "npm:1.3.1"
-    fresh: "npm:0.5.2"
-    http-errors: "npm:2.0.0"
+    finalhandler: "npm:~1.3.1"
+    fresh: "npm:~0.5.2"
+    http-errors: "npm:~2.0.0"
     merge-descriptors: "npm:1.0.3"
     methods: "npm:~1.1.2"
-    on-finished: "npm:2.4.1"
+    on-finished: "npm:~2.4.1"
     parseurl: "npm:~1.3.3"
-    path-to-regexp: "npm:0.1.12"
+    path-to-regexp: "npm:~0.1.12"
     proxy-addr: "npm:~2.0.7"
-    qs: "npm:6.13.0"
+    qs: "npm:~6.15.1"
     range-parser: "npm:~1.2.1"
     safe-buffer: "npm:5.2.1"
-    send: "npm:0.19.0"
-    serve-static: "npm:1.16.2"
+    send: "npm:~0.19.0"
+    serve-static: "npm:~1.16.2"
     setprototypeof: "npm:1.2.0"
-    statuses: "npm:2.0.1"
+    statuses: "npm:~2.0.1"
     type-is: "npm:~1.6.18"
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
-  checksum: 10c0/38168fd0a32756600b56e6214afecf4fc79ec28eca7f7a91c2ab8d50df4f47562ca3f9dee412da7f5cea6b1a1544b33b40f9f8586dbacfbdada0fe90dbb10a1f
+  checksum: 10c0/d06dd4379fd217440b30f8abbe45f0e74931114c1395034f03e7d635196ecdab530d4835a1962a6aa34838d61967dc6f1f77846999bba3032373e9e714222c44
   languageName: node
   linkType: hard
 
@@ -19524,18 +19604,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"finalhandler@npm:1.3.1":
-  version: 1.3.1
-  resolution: "finalhandler@npm:1.3.1"
+"finalhandler@npm:~1.3.1":
+  version: 1.3.2
+  resolution: "finalhandler@npm:1.3.2"
   dependencies:
     debug: "npm:2.6.9"
     encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
-    on-finished: "npm:2.4.1"
+    on-finished: "npm:~2.4.1"
     parseurl: "npm:~1.3.3"
-    statuses: "npm:2.0.1"
+    statuses: "npm:~2.0.2"
     unpipe: "npm:~1.0.0"
-  checksum: 10c0/d38035831865a49b5610206a3a9a9aae4e8523cbbcd01175d0480ffbf1278c47f11d89be3ca7f617ae6d94f29cf797546a4619cd84dd109009ef33f12f69019f
+  checksum: 10c0/435a4fd65e4e4e4c71bb5474980090b73c353a123dd415583f67836bdd6516e528cf07298e219a82b94631dee7830eae5eece38d3c178073cf7df4e8c182f413
   languageName: node
   linkType: hard
 
@@ -19809,7 +19889,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fresh@npm:0.5.2, fresh@npm:~0.5.2":
+"fresh@npm:~0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 10c0/c6d27f3ed86cc5b601404822f31c900dd165ba63fff8152a3ef714e2012e7535027063bc67ded4cb5b3a49fa596495d46cacd9f47d6328459cf570f08b7d9e5a
@@ -21046,19 +21126,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:2.0.0":
-  version: 2.0.0
-  resolution: "http-errors@npm:2.0.0"
-  dependencies:
-    depd: "npm:2.0.0"
-    inherits: "npm:2.0.4"
-    setprototypeof: "npm:1.2.0"
-    statuses: "npm:2.0.1"
-    toidentifier: "npm:1.0.1"
-  checksum: 10c0/fc6f2715fe188d091274b5ffc8b3657bd85c63e969daa68ccb77afb05b071a4b62841acb7a21e417b5539014dff2ebf9550f0b14a9ff126f2734a7c1387f8e19
-  languageName: node
-  linkType: hard
-
 "http-errors@npm:^1.6.3, http-errors@npm:~1.8.0":
   version: 1.8.1
   resolution: "http-errors@npm:1.8.1"
@@ -21081,6 +21148,19 @@ __metadata:
     setprototypeof: "npm:1.1.0"
     statuses: "npm:>= 1.4.0 < 2"
   checksum: 10c0/17ec4046ee974477778bfdd525936c254b872054703ec2caa4d6f099566b8adade636ae6aeeacb39302c5cd6e28fb407ebd937f500f5010d0b6850750414ff78
+  languageName: node
+  linkType: hard
+
+"http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "http-errors@npm:2.0.1"
+  dependencies:
+    depd: "npm:~2.0.0"
+    inherits: "npm:~2.0.4"
+    setprototypeof: "npm:~1.2.0"
+    statuses: "npm:~2.0.2"
+    toidentifier: "npm:~1.0.1"
+  checksum: 10c0/fb38906cef4f5c83952d97661fe14dc156cb59fe54812a42cd448fa57b5c5dfcb38a40a916957737bd6b87aab257c0648d63eb5b6a9ca9f548e105b6072712d4
   languageName: node
   linkType: hard
 
@@ -21256,21 +21336,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
-  version: 0.4.24
-  resolution: "iconv-lite@npm:0.4.24"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3"
-  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
-  languageName: node
-  linkType: hard
-
 "iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.4.24, iconv-lite@npm:~0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
   languageName: node
   linkType: hard
 
@@ -26263,7 +26343,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:2.4.1, on-finished@npm:^2.3.0, on-finished@npm:^2.4.1":
+"on-finished@npm:^2.3.0, on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -26998,13 +27078,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.12":
-  version: 0.1.12
-  resolution: "path-to-regexp@npm:0.1.12"
-  checksum: 10c0/1c6ff10ca169b773f3bba943bbc6a07182e332464704572962d277b900aeee81ac6aa5d060ff9e01149636c30b1f63af6e69dd7786ba6e0ddb39d4dee1f0645b
-  languageName: node
-  linkType: hard
-
 "path-to-regexp@npm:3.3.0":
   version: 3.3.0
   resolution: "path-to-regexp@npm:3.3.0"
@@ -27016,6 +27089,13 @@ __metadata:
   version: 8.2.0
   resolution: "path-to-regexp@npm:8.2.0"
   checksum: 10c0/ef7d0a887b603c0a142fad16ccebdcdc42910f0b14830517c724466ad676107476bba2fe9fffd28fd4c141391ccd42ea426f32bb44c2c82ecaefe10c37b90f5a
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:~0.1.12":
+  version: 0.1.13
+  resolution: "path-to-regexp@npm:0.1.13"
+  checksum: 10c0/1cae3921739c154a8926e136185a10c916f79a249b9072a5001b266d96e193860ca03867e8e8cc808b786862d750f427ed93686bc259355442c3407a62deab1a
   languageName: node
   linkType: hard
 
@@ -28192,21 +28272,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.13.0":
-  version: 6.13.0
-  resolution: "qs@npm:6.13.0"
+"qs@npm:^6.10.1, qs@npm:^6.10.3, qs@npm:^6.12.2, qs@npm:^6.12.3, qs@npm:^6.9.4, qs@npm:~6.15.1":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
   dependencies:
-    side-channel: "npm:^1.0.6"
-  checksum: 10c0/62372cdeec24dc83a9fb240b7533c0fdcf0c5f7e0b83343edd7310f0ab4c8205a5e7c56406531f2e47e1b4878a3821d652be4192c841de5b032ca83619d8f860
-  languageName: node
-  linkType: hard
-
-"qs@npm:^6.10.1, qs@npm:^6.10.3, qs@npm:^6.12.2, qs@npm:^6.12.3, qs@npm:^6.9.4":
-  version: 6.13.1
-  resolution: "qs@npm:6.13.1"
-  dependencies:
-    side-channel: "npm:^1.0.6"
-  checksum: 10c0/5ef527c0d62ffca5501322f0832d800ddc78eeb00da3b906f1b260ca0492721f8cdc13ee4b8fd8ac314a6ec37b948798c7b603ccc167e954088df392092f160c
+    side-channel: "npm:^1.1.0"
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
   languageName: node
   linkType: hard
 
@@ -28356,15 +28427,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raw-body@npm:2.5.2, raw-body@npm:^2.4.1":
-  version: 2.5.2
-  resolution: "raw-body@npm:2.5.2"
+"raw-body@npm:^2.4.1, raw-body@npm:~2.5.3":
+  version: 2.5.3
+  resolution: "raw-body@npm:2.5.3"
   dependencies:
-    bytes: "npm:3.1.2"
-    http-errors: "npm:2.0.0"
-    iconv-lite: "npm:0.4.24"
-    unpipe: "npm:1.0.0"
-  checksum: 10c0/b201c4b66049369a60e766318caff5cb3cc5a900efd89bdac431463822d976ad0670912c931fdbdcf5543207daf6f6833bca57aa116e1661d2ea91e12ca692c4
+    bytes: "npm:~3.1.2"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.4.24"
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/449844344fc90547fb994383a494b83300e4f22199f146a79f68d78a199a8f2a923ea9fd29c3be979bfd50291a3884733619ffc15ba02a32e703b612f8d3f74a
   languageName: node
   linkType: hard
 
@@ -30055,24 +30126,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"send@npm:0.19.0":
-  version: 0.19.0
-  resolution: "send@npm:0.19.0"
+"send@npm:~0.19.0, send@npm:~0.19.1":
+  version: 0.19.2
+  resolution: "send@npm:0.19.2"
   dependencies:
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
     destroy: "npm:1.2.0"
-    encodeurl: "npm:~1.0.2"
+    encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     etag: "npm:~1.8.1"
-    fresh: "npm:0.5.2"
-    http-errors: "npm:2.0.0"
+    fresh: "npm:~0.5.2"
+    http-errors: "npm:~2.0.1"
     mime: "npm:1.6.0"
     ms: "npm:2.1.3"
-    on-finished: "npm:2.4.1"
+    on-finished: "npm:~2.4.1"
     range-parser: "npm:~1.2.1"
-    statuses: "npm:2.0.1"
-  checksum: 10c0/ea3f8a67a8f0be3d6bf9080f0baed6d2c51d11d4f7b4470de96a5029c598a7011c497511ccc28968b70ef05508675cebff27da9151dd2ceadd60be4e6cf845e3
+    statuses: "npm:~2.0.2"
+  checksum: 10c0/20c2389fe0fdf3fc499938cac598bc32272287e993c4960717381a10de8550028feadfb9076f959a3a3ebdea42e1f690e116f0d16468fa56b9fd41866d3dc267
   languageName: node
   linkType: hard
 
@@ -30125,15 +30196,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-static@npm:1.16.2":
-  version: 1.16.2
-  resolution: "serve-static@npm:1.16.2"
+"serve-static@npm:~1.16.2":
+  version: 1.16.3
+  resolution: "serve-static@npm:1.16.3"
   dependencies:
     encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     parseurl: "npm:~1.3.3"
-    send: "npm:0.19.0"
-  checksum: 10c0/528fff6f5e12d0c5a391229ad893910709bc51b5705962b09404a1d813857578149b8815f35d3ee5752f44cd378d0f31669d4b1d7e2d11f41e08283d5134bd1f
+    send: "npm:~0.19.1"
+  checksum: 10c0/36320397a073c71bedf58af48a4a100fe6d93f07459af4d6f08b9a7217c04ce2a4939e0effd842dc7bece93ffcd59eb52f58c4fff2a8e002dc29ae6b219cd42b
   languageName: node
   linkType: hard
 
@@ -30201,7 +30272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setprototypeof@npm:1.2.0":
+"setprototypeof@npm:1.2.0, setprototypeof@npm:~1.2.0":
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: 10c0/68733173026766fa0d9ecaeb07f0483f4c2dc70ca376b3b7c40b7cda909f94b0918f6c5ad5ce27a9160bdfb475efaa9d5e705a11d8eaae18f9835d20976028bc
@@ -30288,7 +30359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4, side-channel@npm:^1.0.6, side-channel@npm:^1.1.0":
+"side-channel@npm:^1.0.4, side-channel@npm:^1.1.0":
   version: 1.1.0
   resolution: "side-channel@npm:1.1.0"
   dependencies:
@@ -30772,17 +30843,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:2.0.1":
-  version: 2.0.1
-  resolution: "statuses@npm:2.0.1"
-  checksum: 10c0/34378b207a1620a24804ce8b5d230fea0c279f00b18a7209646d5d47e419d1cc23e7cbf33a25a1e51ac38973dc2ac2e1e9c647a8e481ef365f77668d72becfd0
-  languageName: node
-  linkType: hard
-
 "statuses@npm:>= 1.4.0 < 2, statuses@npm:>= 1.5.0 < 2, statuses@npm:^1.5.0, statuses@npm:~1.5.0":
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: 10c0/e433900956357b3efd79b1c547da4d291799ac836960c016d10a98f6a810b1b5c0dcc13b5a7aa609a58239b5190e1ea176ad9221c2157d2fd1c747393e6b2940
+  languageName: node
+  linkType: hard
+
+"statuses@npm:~2.0.1, statuses@npm:~2.0.2":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
   languageName: node
   linkType: hard
 
@@ -31837,7 +31908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toidentifier@npm:1.0.1":
+"toidentifier@npm:1.0.1, toidentifier@npm:~1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
@@ -32532,6 +32603,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^7.24.5":
+  version: 7.25.0
+  resolution: "undici@npm:7.25.0"
+  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
+  languageName: node
+  linkType: hard
+
 "unicode-canonical-property-names-ecmascript@npm:^2.0.0":
   version: 2.0.1
   resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.1"
@@ -32734,7 +32812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
+"unpipe@npm:~1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 10c0/193400255bd48968e5c5383730344fbb4fa114cdedfab26e329e50dd2d81b134244bb8a72c6ac1b10ab0281a58b363d06405632c9d49ca9dfd5e90cbd7d0f32c
@@ -33994,12 +34072,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-json-schema@npm:^3.20.4, zod-to-json-schema@npm:^3.21.4":
-  version: 3.24.1
-  resolution: "zod-to-json-schema@npm:3.24.1"
+"zod-to-json-schema@npm:^3.20.4, zod-to-json-schema@npm:^3.21.4, zod-to-json-schema@npm:^3.25.1":
+  version: 3.25.2
+  resolution: "zod-to-json-schema@npm:3.25.2"
   peerDependencies:
-    zod: ^3.24.1
-  checksum: 10c0/dd4e72085003e41a3f532bd00061f27041418a4eb176aa6ce33042db08d141bd37707017ee9117d97738ae3f22fc3e1404ea44e6354634ac5da79d7d3173b4ee
+    zod: ^3.25.28 || ^4
+  checksum: 10c0/dd300554393903022487688af14fbda5c719ba8179702bb55b3aa86318830467f0f7beb7d654036975ac963dc4843b72e59636448bfff9a0608f277bb6a14939
   languageName: node
   linkType: hard
 
@@ -34012,10 +34090,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.22.4":
-  version: 3.24.1
-  resolution: "zod@npm:3.24.1"
-  checksum: 10c0/0223d21dbaa15d8928fe0da3b54696391d8e3e1e2d0283a1a070b5980a1dbba945ce631c2d1eccc088fdbad0f2dfa40155590bf83732d3ac4fcca2cc9237591b
+"zod-validation-error@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "zod-validation-error@npm:4.0.2"
+  peerDependencies:
+    zod: ^3.25.0 || ^4.0.0
+  checksum: 10c0/0ccfec48c46de1be440b719cd02044d4abb89ed0e14c13e637cd55bf29102f67ccdba373f25def0fc7130e5f15025be4d557a7edcc95d5a3811599aade689e1b
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.4, zod@npm:^3.25.76":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.76 || ^4.0.0":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
   languageName: node
   linkType: hard
 

--- a/workspaces/scaffolder-backend-module-gcp/yarn.lock
+++ b/workspaces/scaffolder-backend-module-gcp/yarn.lock
@@ -5908,6 +5908,8 @@ __metadata:
     "@backstage/plugin-scaffolder-node-test-utils": "npm:^0.1.18"
     "@google-cloud/resource-manager": "npm:^6.0.0"
     "@google-cloud/secret-manager": "npm:^5.6.0"
+    "@google-cloud/storage": "npm:^7.0.0"
+    google-auth-library: "npm:^9.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Introduce a Google Access Token field extension for GCP authentication and enable the usage of user OAuth tokens in GCP actions. This enhances flexibility in authentication methods for GCP services.

Please do give this a through review, as I leaned pretty heavy on AI to write this. 